### PR TITLE
feat: Add iOS specific extension methods

### DIFF
--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryApple.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryApple.kt
@@ -2,6 +2,7 @@ package io.sentry.kotlin.multiplatform
 
 import cocoapods.Sentry.SentryOptions
 import cocoapods.Sentry.SentrySDK
+import platform.Foundation.NSError
 import platform.Foundation.NSException
 
 internal actual object SentryBridge {
@@ -30,4 +31,12 @@ internal actual object SentryBridge {
         sentryAppleOptions.attachStacktrace = options.attachStackTrace
         return sentryAppleOptions
     }
+}
+
+fun SentryKMP.captureError(error: NSError) {
+    SentrySDK.captureError(error)
+}
+
+fun SentryKMP.captureException(exception: NSException) {
+    SentrySDK.captureException(exception)
 }

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryApple.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryApple.kt
@@ -17,7 +17,7 @@ internal actual object SentryBridge {
     }
 
     actual fun captureException(throwable: Throwable) {
-        val exception = NSException("", throwable.message, null)
+        val exception = NSException(throwable::class.simpleName, throwable.message, null)
         SentrySDK.captureException(exception)
     }
 


### PR DESCRIPTION
This allows the user to capture exceptions and errors directly in swift code and it also serves as a convenience method for the iosMain part of the KMP app. Additionally, the NSException creation has been changed to use the throwable name which is more descriptive.

