### PR TITLE
chore: Bump Sentry Cocoa SDK version to 7.21.0

### DIFF
--- a/sentry-kotlin-multiplatform/build.gradle.kts
+++ b/sentry-kotlin-multiplatform/build.gradle.kts
@@ -72,7 +72,7 @@ kotlin {
             summary = "Official Sentry SDK for iOS / tvOS / macOS / watchOS"
             homepage = "https://github.com/getsentry/sentry-cocoa"
 
-            pod("Sentry", "~> 7.19.0")
+            pod("Sentry", "~> 7.21.0")
 
             ios.deploymentTarget = "9.0"
             // osx.deploymentTarget = "10.10"

--- a/sentry-kotlin-multiplatform/sentry_kotlin_multiplatform.podspec
+++ b/sentry-kotlin-multiplatform/sentry_kotlin_multiplatform.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/sentry_kotlin_multiplatform.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target = '9.0'
-    spec.dependency 'Sentry', '~> 7.19.0'
+    spec.dependency 'Sentry', '~> 7.21.0'
                 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':sentry-kotlin-multiplatform',

--- a/sentry-samples/kmp-app/iosApp/Podfile.lock
+++ b/sentry-samples/kmp-app/iosApp/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Sentry (7.19.0):
-    - Sentry/Core (= 7.19.0)
-  - Sentry/Core (7.19.0)
+  - Sentry (7.21.0):
+    - Sentry/Core (= 7.21.0)
+  - Sentry/Core (7.21.0)
   - shared (1.0):
-    - Sentry (~> 7.19.0)
+    - Sentry (~> 7.21.0)
 
 DEPENDENCIES:
   - shared (from `../shared`)
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
     :path: "../shared"
 
 SPEC CHECKSUMS:
-  Sentry: d6b16e66a0ad0c39a0b76d9a1194e68e78c37ce6
-  shared: 6958d21bde60a73ac35a9b466bf90e2fac28741a
+  Sentry: 194d0a2d4d6ef92c9c08c98d998340b0a63efd81
+  shared: 5f56305f5173a9f257ee5222895d778e649f8727
 
 PODFILE CHECKSUM: f282da88f39e69507b0a255187c8a6b644477756
 

--- a/sentry-samples/kmp-app/shared/build.gradle.kts
+++ b/sentry-samples/kmp-app/shared/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
         ios.deploymentTarget = "14.1"
         podfile = project.file("../iosApp/Podfile")
 
-        pod("Sentry", "~> 7.19.0")
+        pod("Sentry", "~> 7.21.0")
 
         framework {
             baseName = "shared"

--- a/sentry-samples/kmp-app/shared/shared.podspec
+++ b/sentry-samples/kmp-app/shared/shared.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/shared.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target = '14.1'
-    spec.dependency 'Sentry', '~> 7.19.0'
+    spec.dependency 'Sentry', '~> 7.21.0'
                 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':sentry-samples:kmp-app:shared',


### PR DESCRIPTION
This version introduces fixes to false positives of OutOfMemory errors in simulators:

Fixes: #15 

Related: https://github.com/getsentry/sentry-cocoa/pull/1970