### PR TITLE
Fix compilation error caused by not calling `toString` 

### DIFF
--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/UserExtensions.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/UserExtensions.kt
@@ -16,7 +16,7 @@ internal fun User.toCocoaUser(): CocoaUser {
 internal fun CocoaUser.toKmpUser(): User {
     val outerScope = this
     return User().apply {
-        id = outerScope.userId
+        id = outerScope.userId.toString()
         username = outerScope.username.toString()
         email = outerScope.email.toString()
         ipAddress = outerScope.ipAddress.toString()


### PR DESCRIPTION
In `commonAppleMain` UserExtensions there was a missed `toString` call that was breaking compilation