### PR TITLE
fix: build and bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cocoapods {
   // ...
   
   // Make sure Sentry Cocoa in your project matches this version
-  pod("Sentry", "~> 7.21.0")
+  pod("Sentry", "~> 8.2.0")
 
   framework {
     baseName = "shared"
@@ -176,7 +176,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 ## Debug Symbols for Apple targets
 
-A dSYM upload is required for Sentry to symbolicate your crash logs for viewing. The symbolication process unscrambles Apple’s crash logs to reveal the function, variables, file names, and line numbers of the crash. The dSYM file can be uploaded through the sentry-cli tool or through a Fastlane action. Please visit our [sentry.io guide](https://docs.sentry.io/clients/cocoa/dsym/) to get started on uploading debug symbols.
+A dSYM upload is required for Sentry to symbolicate your crash logs for viewing. The symbolication process unscrambles Apple’s crash logs to reveal the function, variables, file names, and line numbers of the crash. The dSYM file can be uploaded through the sentry-cli tool or through a Fastlane action. Please visit our [sentry.io guide](https://docs.sentry.io/platforms/apple/dsym/) to get started on uploading debug symbols.
 
  ## Troubleshooting
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,48 +3,21 @@ import com.vanniktech.maven.publish.MavenPublishPlugin
 import com.vanniktech.maven.publish.MavenPublishPluginExtension
 
 plugins {
-    id("com.vanniktech.maven.publish") version "0.18.0"
-    id("com.diffplug.spotless") version "6.7.2"
-}
-
-buildscript {
-    repositories {
-        gradlePluginPortal()
-        google()
-    }
-    dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
-        classpath("com.android.tools.build:gradle:7.4.1")
-    }
-}
-
-spotless {
-    lineEndings = LineEnding.UNIX
-
-    kotlin {
-        target("**/*.kt")
-        ktlint()
-    }
-    kotlinGradle {
-        target("**/*.kts")
-        ktlint()
-    }
+    id(Config.gradleMavenPublishPlugin).version(Config.gradleMavenPublishPluginVersion)
+    id(Config.QualityPlugins.spotless).version(Config.QualityPlugins.spotlessVersion)
+    kotlin(Config.multiplatform).version(Config.kotlinVersion).apply(false)
+    kotlin(Config.cocoapods).version(Config.kotlinVersion).apply(false)
+    id(Config.jetpackCompose).version(Config.composeVersion).apply(false)
+    id(Config.androidGradle).version(Config.agpVersion).apply(false)
 }
 
 allprojects {
-    repositories {
-        mavenCentral()
-        mavenLocal()
-        google()
-    }
     group = "io.sentry"
     version = properties["versionName"].toString()
-
-    apply(plugin = "com.diffplug.spotless")
 }
 
 subprojects {
-    if (!this.name.contains("samples") && !this.name.contains("shared")) {
+    if (this.name.contains("sentry-kotlin-multiplatform")) {
         apply<DistributionPlugin>()
 
         val sep = File.separator
@@ -73,5 +46,18 @@ subprojects {
                 releaseSigningEnabled = false
             }
         }
+    }
+}
+
+spotless {
+    lineEndings = LineEnding.UNIX
+
+    kotlin {
+        target("**/*.kt")
+        ktlint()
+    }
+    kotlinGradle {
+        target("**/*.kts")
+        ktlint()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import com.vanniktech.maven.publish.MavenPublishPlugin
 import com.vanniktech.maven.publish.MavenPublishPluginExtension
 
 plugins {
-    `maven-publish`
     id("com.vanniktech.maven.publish") version "0.18.0"
     id("com.diffplug.spotless") version "6.7.2"
 }
@@ -12,7 +11,6 @@ buildscript {
     repositories {
         gradlePluginPortal()
         google()
-        mavenCentral()
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
-        classpath("com.android.tools.build:gradle:7.2.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
+        classpath("com.android.tools.build:gradle:7.4.1")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,5 +9,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,6 @@ repositories {
 
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = properties["jvm.version"].toString()
     }
 }

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,0 +1,49 @@
+object Config {
+    val agpVersion = "7.4.2"
+    val kotlinVersion = "1.8.0"
+    val composeVersion = "1.3.1-rc01"
+    val gradleMavenPublishPluginVersion = "0.18.0"
+
+    val multiplatform = "multiplatform"
+    val cocoapods = "native.cocoapods"
+    val jetpackCompose = "org.jetbrains.compose"
+    val gradleMavenPublishPlugin = "com.vanniktech.maven.publish"
+    val androidGradle = "com.android.library"
+
+    object QualityPlugins {
+        val spotless = "com.diffplug.spotless"
+        val spotlessVersion = "6.11.0"
+    }
+
+    object Libs {
+        val kotlinStd = "org.jetbrains.kotlin:kotlin-stdlib"
+
+        val sentryJavaVersion = "6.14.0"
+        val sentryAndroid = "io.sentry:sentry-android:$sentryJavaVersion"
+        val sentryJava = "io.sentry:sentry:$sentryJavaVersion"
+
+        val sentryCocoaVersion = "~> 8.2.0"
+        val sentryCocoa = "Sentry"
+    }
+
+    object TestLibs {
+        val kotlinCommon = "org.jetbrains.kotlin:kotlin-test-common"
+        val kotlinCommonAnnotation = "org.jetbrains.kotlin:kotlin-test-annotations-common"
+        val kotlinJunit = "org.jetbrains.kotlin:kotlin-test-junit"
+    }
+
+    object Android {
+        private val sdkVersion = 33
+
+        val minSdkVersion = 16
+        val targetSdkVersion = sdkVersion
+        val compileSdkVersion = sdkVersion
+    }
+
+    object Cocoa {
+        val iosDeploymentTarget = "11.0"
+        val osxDeploymentTarget = "10.13"
+        val tvosDeploymentTarget = "11.0"
+        val watchosDeploymentTarget = "4.0"
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ kotlin.mpp.enableCompatibilityMetadataVariant=true
 kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.enableHierarchicalCommonization=true
+kotlin.mpp.androidSourceSetLayoutVersion=2
 
 # publication pom properties
 POM_NAME=Sentry Kotlin Multiplatform SDK

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,13 +8,16 @@ android.useAndroidX=true
 # Jetpack Compose
 compose.version=1.3.1-rc01
 
+# JVM target when compiling Kotlin
+jvm.version=1.8
+
 # Release information
 versionName=0.0.1
 
 # Increase memory for in-process compiler execution.
 org.gradle.jvmargs=-Xmx3g
 
-# because of: Please try to disable compiler caches and rerun the build. To disable compiler caches, add the following line to the gradle.properties file in the project's root directory
+# Because of: Please try to disable compiler caches and rerun the build. To disable compiler caches, add the following line to the gradle.properties file in the project's root directory
 kotlin.native.cacheKind=none
 
 # https://kotlinlang.org/docs/migrating-multiplatform-project-to-14.html#migrate-to-the-hierarchical-project-structure
@@ -25,7 +28,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.enableHierarchicalCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
-# publication pom properties
+# Publication pom properties
 POM_NAME=Sentry Kotlin Multiplatform SDK
 POM_DESCRIPTION=SDK for sentry.io
 POM_URL=https://github.com/getsentry/sentry-kotlin-multiplatform

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 # Kotlin
-kotlin.version=1.7.10
+kotlin.version=1.8.0
 kotlin.incremental.multiplatform=true
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
 android.useAndroidX=true
 
 # Jetpack Compose
-compose.version=1.2.0-alpha01-dev753
+compose.version=1.3.1-rc01
 
 # Release information
 versionName=0.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Feb 27 16:36:52 CET 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/sentry-kotlin-multiplatform/build.gradle.kts
+++ b/sentry-kotlin-multiplatform/build.gradle.kts
@@ -52,13 +52,13 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation("io.sentry:sentry-android:6.3.1") {
+                implementation("io.sentry:sentry-android:6.14.0") {
                     // avoid duplicate dependencies since we depend on commonJvmMain
                     exclude("io.sentry", "sentry")
                 }
             }
         }
-        val androidTest by getting
+        val androidUnitTest by getting
         val jvmMain by getting
         val jvmTest by getting
 
@@ -67,13 +67,13 @@ kotlin {
             jvmMain.dependsOn(this)
             androidMain.dependsOn(this)
             dependencies {
-                implementation("io.sentry:sentry:6.3.1")
+                implementation("io.sentry:sentry:6.14.0")
             }
         }
         val commonJvmTest by creating {
             dependsOn(commonTest)
             jvmTest.dependsOn(this)
-            androidTest.dependsOn(this)
+            androidUnitTest.dependsOn(this)
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-test-junit")
             }

--- a/sentry-kotlin-multiplatform/build.gradle.kts
+++ b/sentry-kotlin-multiplatform/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = Config.Android.compileSdkVersion
     defaultConfig {
-        minSdk = 16
+        minSdk = Config.Android.minSdkVersion
     }
 
     buildTypes {
@@ -18,9 +18,6 @@ android {
             isMinifyEnabled = false
         }
     }
-
-    // linking the manifest file manually due to having it in the "androidMain" source set
-    namespace = "io.sentry.kotlin.multiplatform"
 }
 
 kotlin {
@@ -40,19 +37,19 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-stdlib")
+                implementation(Config.Libs.kotlinStd)
             }
         }
         val commonTest by getting {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-test-common")
-                implementation("org.jetbrains.kotlin:kotlin-test-annotations-common")
+                implementation(Config.TestLibs.kotlinCommon)
+                implementation(Config.TestLibs.kotlinCommonAnnotation)
             }
         }
 
         val androidMain by getting {
             dependencies {
-                implementation("io.sentry:sentry-android:6.14.0") {
+                implementation(Config.Libs.sentryAndroid) {
                     // avoid duplicate dependencies since we depend on commonJvmMain
                     exclude("io.sentry", "sentry")
                 }
@@ -67,7 +64,7 @@ kotlin {
             jvmMain.dependsOn(this)
             androidMain.dependsOn(this)
             dependencies {
-                implementation("io.sentry:sentry:6.14.0")
+                implementation(Config.Libs.sentryJava)
             }
         }
         val commonJvmTest by creating {
@@ -75,8 +72,20 @@ kotlin {
             jvmTest.dependsOn(this)
             androidUnitTest.dependsOn(this)
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-test-junit")
+                implementation(Config.TestLibs.kotlinJunit)
             }
+        }
+
+        cocoapods {
+            summary = "Official Sentry SDK Kotlin Multiplatform"
+            homepage = "https://github.com/getsentry/sentry-kotlin-multiplatform"
+
+            pod(Config.Libs.sentryCocoa, Config.Libs.sentryCocoaVersion)
+
+            ios.deploymentTarget = Config.Cocoa.iosDeploymentTarget
+            osx.deploymentTarget = Config.Cocoa.osxDeploymentTarget
+            tvos.deploymentTarget = Config.Cocoa.tvosDeploymentTarget
+            watchos.deploymentTarget = Config.Cocoa.watchosDeploymentTarget
         }
 
         val iosMain by getting
@@ -134,18 +143,6 @@ kotlin {
             dependsOn(commonTest)
             commonIosTest.dependsOn(this)
             commonTvWatchMacOsTest.dependsOn(this)
-        }
-
-        cocoapods {
-            summary = "Official Sentry SDK Kotlin Multiplatform"
-            homepage = "https://github.com/getsentry/sentry-kotlin-multiplatform"
-
-            pod("Sentry", "~> 8.2.0")
-
-            ios.deploymentTarget = "11.0"
-            osx.deploymentTarget = "10.13"
-            tvos.deploymentTarget = "11.0"
-            watchos.deploymentTarget = "4.0"
         }
     }
 

--- a/sentry-kotlin-multiplatform/build.gradle.kts
+++ b/sentry-kotlin-multiplatform/build.gradle.kts
@@ -8,10 +8,9 @@ plugins {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 33
     defaultConfig {
         minSdk = 16
-        targetSdk = 30
     }
 
     buildTypes {
@@ -19,8 +18,9 @@ android {
             isMinifyEnabled = false
         }
     }
+
     // linking the manifest file manually due to having it in the "androidMain" source set
-    sourceSets.getByName("main").manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    namespace = "io.sentry.kotlin.multiplatform"
 }
 
 kotlin {
@@ -140,12 +140,12 @@ kotlin {
             summary = "Official Sentry SDK Kotlin Multiplatform"
             homepage = "https://github.com/getsentry/sentry-kotlin-multiplatform"
 
-            pod("Sentry", "~> 7.24.1")
+            pod("Sentry", "~> 8.2.0")
 
-            ios.deploymentTarget = "9.0"
-            osx.deploymentTarget = "10.10"
-            tvos.deploymentTarget = "9.0"
-            watchos.deploymentTarget = "2.0"
+            ios.deploymentTarget = "11.0"
+            osx.deploymentTarget = "10.13"
+            tvos.deploymentTarget = "11.0"
+            watchos.deploymentTarget = "4.0"
         }
     }
 

--- a/sentry-kotlin-multiplatform/sentry_kotlin_multiplatform.podspec
+++ b/sentry-kotlin-multiplatform/sentry_kotlin_multiplatform.podspec
@@ -8,11 +8,11 @@ Pod::Spec.new do |spec|
     spec.summary                  = 'Official Sentry SDK Kotlin Multiplatform'
     spec.vendored_frameworks      = 'build/cocoapods/framework/sentry_kotlin_multiplatform.framework'
     spec.libraries                = 'c++'
-    spec.ios.deployment_target = '9.0'
-    spec.osx.deployment_target = '10.10'
-    spec.tvos.deployment_target = '9.0'
-    spec.watchos.deployment_target = '2.0'
-    spec.dependency 'Sentry', '~> 7.24.1'
+    spec.ios.deployment_target = '11.0'
+    spec.osx.deployment_target = '10.13'
+    spec.tvos.deployment_target = '11.0'
+    spec.watchos.deployment_target = '4.0'
+    spec.dependency 'Sentry', '~> 8.2.0'
                 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':sentry-kotlin-multiplatform',
@@ -25,8 +25,8 @@ Pod::Spec.new do |spec|
             :execution_position => :before_compile,
             :shell_path => '/bin/sh',
             :script => <<-SCRIPT
-                if [ "YES" = "$COCOAPODS_SKIP_KOTLIN_BUILD" ]; then
-                  echo "Skipping Gradle build task invocation due to COCOAPODS_SKIP_KOTLIN_BUILD environment variable set to \"YES\""
+                if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
+                  echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
                   exit 0
                 fi
                 set -ev

--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/Attachment.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/Attachment.kt
@@ -17,7 +17,7 @@ actual class Attachment : IAttachment {
         get() = cocoaAttachment.data?.toByteArray()
 
     actual override val contentType: String?
-        get() = cocoaAttachment.contentType
+        get() = cocoaAttachment.contentType ?: "application/octet-stream"
 
     actual companion object {
         actual fun fromScreenshot(screenshotBytes: ByteArray): Attachment {

--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/Attachment.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/Attachment.kt
@@ -17,7 +17,7 @@ actual class Attachment : IAttachment {
         get() = cocoaAttachment.data?.toByteArray()
 
     actual override val contentType: String?
-        get() = cocoaAttachment.contentType ?: "application/octet-stream"
+        get() = cocoaAttachment.contentType
 
     actual companion object {
         actual fun fromScreenshot(screenshotBytes: ByteArray): Attachment {

--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
@@ -19,7 +19,9 @@ internal fun CocoaSentryOptions.applyCocoaBaseOptions(options: SentryOptions) {
     this.dsn = options.dsn
     this.attachStacktrace = options.attachStackTrace
     this.dist = options.dist
-    this.environment = options.environment
+    options.environment?.let {
+        this.environment = it
+    }
     this.releaseName = options.release
     this.debug = options.debug
     this.sessionTrackingIntervalMillis = options.sessionTrackingIntervalMillis.convert()

--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/protocol/SentryId.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/protocol/SentryId.kt
@@ -11,8 +11,11 @@ actual data class SentryId actual constructor(val sentryIdString: String) : ISen
     private var cocoaSentryId: CocoaSentryId? = null
 
     init {
-        cocoaSentryId = if (sentryIdString.isEmpty()) CocoaSentryId.empty()
-        else CocoaSentryId(sentryIdString)
+        cocoaSentryId = if (sentryIdString.isEmpty()) {
+            CocoaSentryId.empty()
+        } else {
+            CocoaSentryId(sentryIdString)
+        }
     }
 
     actual override fun toString(): String {

--- a/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/Attachment.kt
+++ b/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/Attachment.kt
@@ -14,7 +14,7 @@ actual class Attachment : IAttachment {
         get() = jvmAttachment.bytes
 
     actual override val contentType: String?
-        get() = jvmAttachment.contentType ?: "application/octet-stream"
+        get() = jvmAttachment.contentType
 
     actual companion object {
         actual fun fromScreenshot(screenshotBytes: ByteArray): Attachment {

--- a/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/protocol/SentryId.kt
+++ b/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/protocol/SentryId.kt
@@ -11,8 +11,11 @@ actual data class SentryId actual constructor(val sentryIdString: String) : ISen
     private var jvmSentryId: JvmSentryId? = null
 
     init {
-        jvmSentryId = if (sentryIdString.isEmpty()) JvmSentryId.EMPTY_ID
-        else JvmSentryId(sentryIdString)
+        jvmSentryId = if (sentryIdString.isEmpty()) {
+            JvmSentryId.EMPTY_ID
+        } else {
+            JvmSentryId(sentryIdString)
+        }
     }
 
     actual override fun toString(): String {

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/protocol/Breadcrumb.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/protocol/Breadcrumb.kt
@@ -7,7 +7,7 @@ data class Breadcrumb constructor(
     override var category: String? = null,
     override var message: String? = null,
     override var level: SentryLevel? = null,
-    private var data: MutableMap<String, Any>? = null,
+    private var data: MutableMap<String, Any>? = null
 ) : ISentryBreadcrumb {
 
     companion object {

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/protocol/User.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/protocol/User.kt
@@ -6,7 +6,7 @@ data class User(
     override var username: String = "",
     override var ipAddress: String? = null,
     override var other: MutableMap<String, String>? = null,
-    override var unknown: MutableMap<String, Any>? = null,
+    override var unknown: MutableMap<String, Any>? = null
 ) : ISentryUser {
 
     constructor(user: ISentryUser) : this(

--- a/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/AttachmentTest.kt
+++ b/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/AttachmentTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 
 class AttachmentTest {
 
-    private val defaultContentType = "application/octet-stream"
+    private val defaultContentType = null
 
     @Test
     fun `adding pathname to attachment returns correct values`() {

--- a/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/AttachmentTest.kt
+++ b/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/AttachmentTest.kt
@@ -6,8 +6,6 @@ import kotlin.test.assertEquals
 
 class AttachmentTest {
 
-    private val defaultContentType = null
-
     @Test
     fun `adding pathname to attachment returns correct values`() {
         val pathname = "test"
@@ -16,7 +14,7 @@ class AttachmentTest {
         assertEquals(pathname, attachment.pathname)
         assertEquals(pathname, attachment.filename)
         assertEquals(null, attachment.bytes)
-        assertEquals(defaultContentType, attachment.contentType)
+        assertEquals(null, attachment.contentType)
     }
 
     @Test
@@ -28,7 +26,7 @@ class AttachmentTest {
         assertEquals(pathname, attachment.pathname)
         assertEquals(filename, attachment.filename)
         assertEquals(null, attachment.bytes)
-        assertEquals(defaultContentType, attachment.contentType)
+        assertEquals(null, attachment.contentType)
     }
 
     @Test
@@ -52,7 +50,7 @@ class AttachmentTest {
 
         assertContentEquals(bytes, attachment.bytes)
         assertEquals(filename, attachment.filename)
-        assertEquals(defaultContentType, attachment.contentType)
+        assertEquals(null, attachment.contentType)
         assertEquals(null, attachment.pathname)
     }
 

--- a/sentry-samples/kmp-app/androidApp/build.gradle.kts
+++ b/sentry-samples/kmp-app/androidApp/build.gradle.kts
@@ -7,7 +7,7 @@ android {
     compileSdk = 33
     defaultConfig {
         applicationId = "sample.kpm_app.android"
-        minSdk = 24
+        minSdk = 16
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"

--- a/sentry-samples/kmp-app/androidApp/build.gradle.kts
+++ b/sentry-samples/kmp-app/androidApp/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 33
     defaultConfig {
         applicationId = "sample.kpm_app.android"
-        minSdk = 16
-        targetSdk = 32
+        minSdk = 24
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
     }

--- a/sentry-samples/kmp-app/androidApp/build.gradle.kts
+++ b/sentry-samples/kmp-app/androidApp/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = Config.Android.compileSdkVersion
     defaultConfig {
         applicationId = "sample.kpm_app.android"
-        minSdk = 16
-        targetSdk = 33
+        minSdk = Config.Android.minSdkVersion
+        targetSdk = Config.Android.targetSdkVersion
         versionCode = 1
         versionName = "1.0"
     }

--- a/sentry-samples/kmp-app/androidApp/src/main/java/sample/kmp/app/android/MainActivity.kt
+++ b/sentry-samples/kmp-app/androidApp/src/main/java/sample/kmp/app/android/MainActivity.kt
@@ -42,7 +42,7 @@ class SentryApplication : Application() {
         super.onCreate()
 
         // Initialize Sentry using shared code
-        initializeSentry()
+        initializeSentry(this)
 
         // Shared scope across all platforms
         configureSentryScope()

--- a/sentry-samples/kmp-app/build.gradle.kts
+++ b/sentry-samples/kmp-app/build.gradle.kts
@@ -1,7 +1,0 @@
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        mavenLocal()
-    }
-}

--- a/sentry-samples/kmp-app/desktopApp/src/jvmMain/kotlin/sample.kmp.app.desktop/Main.kt
+++ b/sentry-samples/kmp-app/desktopApp/src/jvmMain/kotlin/sample.kmp.app.desktop/Main.kt
@@ -50,7 +50,6 @@ fun App() {
 
 fun main() = application {
     Window(onCloseRequest = ::exitApplication) {
-
         // Initialize Sentry using shared code
         initializeSentry()
 

--- a/sentry-samples/kmp-app/iosApp/Podfile.lock
+++ b/sentry-samples/kmp-app/iosApp/Podfile.lock
@@ -1,9 +1,12 @@
 PODS:
-  - Sentry (7.21.0):
-    - Sentry/Core (= 7.21.0)
-  - Sentry/Core (7.21.0)
+  - Sentry (8.2.0):
+    - Sentry/Core (= 8.2.0)
+    - SentryPrivate (= 8.2.0)
+  - Sentry/Core (8.2.0):
+    - SentryPrivate (= 8.2.0)
+  - SentryPrivate (8.2.0)
   - shared (1.0):
-    - Sentry (~> 7.21.0)
+    - Sentry (~> 8.2.0)
 
 DEPENDENCIES:
   - shared (from `../shared`)
@@ -11,15 +14,17 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Sentry
+    - SentryPrivate
 
 EXTERNAL SOURCES:
   shared:
     :path: "../shared"
 
 SPEC CHECKSUMS:
-  Sentry: 194d0a2d4d6ef92c9c08c98d998340b0a63efd81
-  shared: 5f56305f5173a9f257ee5222895d778e649f8727
+  Sentry: cf1d35c866266da58964fe7b62526bda93ffcb38
+  SentryPrivate: 2909bcc7b19a827b49e9bde0e56116b08d40dfdf
+  shared: 58db2d6937fef39d8b2c4c237ae769c9fef453f2
 
 PODFILE CHECKSUM: f282da88f39e69507b0a255187c8a6b644477756
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/sentry-samples/kmp-app/shared/build.gradle.kts
+++ b/sentry-samples/kmp-app/shared/build.gradle.kts
@@ -8,10 +8,10 @@ version = "1.0"
 
 kotlin {
     android()
+    jvm()
     iosX64()
     iosArm64()
     iosSimulatorArm64()
-    jvm()
 
     cocoapods {
         summary = "Some description for the Shared Module"
@@ -19,7 +19,7 @@ kotlin {
         ios.deploymentTarget = "14.1"
         podfile = project.file("../iosApp/Podfile")
 
-        pod("Sentry", "~> 7.21.0")
+        pod("Sentry", "~> 8.2.0")
 
         framework {
             baseName = "shared"
@@ -70,10 +70,10 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 16
-        targetSdk = 32
+        minSdk = 24
+        targetSdk = 33
     }
 }

--- a/sentry-samples/kmp-app/shared/build.gradle.kts
+++ b/sentry-samples/kmp-app/shared/build.gradle.kts
@@ -73,7 +73,6 @@ android {
     compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 24
-        targetSdk = 33
+        minSdk = 16
     }
 }

--- a/sentry-samples/kmp-app/shared/build.gradle.kts
+++ b/sentry-samples/kmp-app/shared/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
         ios.deploymentTarget = "14.1"
         podfile = project.file("../iosApp/Podfile")
 
-        pod("Sentry", "~> 8.2.0")
+        pod(Config.Libs.sentryCocoa, Config.Libs.sentryCocoaVersion)
 
         framework {
             baseName = "shared"
@@ -70,9 +70,9 @@ kotlin {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = Config.Android.compileSdkVersion
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 16
+        minSdk = Config.Android.minSdkVersion
     }
 }

--- a/sentry-samples/kmp-app/shared/build.gradle.kts
+++ b/sentry-samples/kmp-app/shared/build.gradle.kts
@@ -46,7 +46,7 @@ kotlin {
         val androidMain by getting {
             dependsOn(commonMain)
         }
-        val androidTest by getting
+        val androidUnitTest by getting
 
         val iosX64Main by getting
         val iosArm64Main by getting

--- a/sentry-samples/kmp-app/shared/shared.podspec
+++ b/sentry-samples/kmp-app/shared/shared.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/shared.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target = '14.1'
-    spec.dependency 'Sentry', '~> 7.21.0'
+    spec.dependency 'Sentry', '~> 8.2.0'
                 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':sentry-samples:kmp-app:shared',
@@ -22,8 +22,8 @@ Pod::Spec.new do |spec|
             :execution_position => :before_compile,
             :shell_path => '/bin/sh',
             :script => <<-SCRIPT
-                if [ "YES" = "$COCOAPODS_SKIP_KOTLIN_BUILD" ]; then
-                  echo "Skipping Gradle build task invocation due to COCOAPODS_SKIP_KOTLIN_BUILD environment variable set to \"YES\""
+                if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
+                  echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
                   exit 0
                 fi
                 set -ev

--- a/sentry-samples/kmp-app/shared/src/commonMain/kotlin/sample.kmp.app/AppSetup.kt
+++ b/sentry-samples/kmp-app/shared/src/commonMain/kotlin/sample.kmp.app/AppSetup.kt
@@ -39,7 +39,7 @@ fun initializeSentry() {
 /** Returns a shared options configuration */
 private fun optionsConfiguration(): OptionsConfiguration {
     return {
-        it.dsn = "https://83f281ded2844eda83a8a413b080dbb9@o447951.ingest.sentry.io/5903800"
+        it.dsn = "https://26ba9de3c0c247f4b2c3e4ee646f2ebb@o1249351.ingest.sentry.io/6587139"
         it.attachStackTrace = true
         it.attachThreads = true
         it.attachScreenshot = true

--- a/sentry-samples/kmp-app/shared/src/commonMain/kotlin/sample.kmp.app/AppSetup.kt
+++ b/sentry-samples/kmp-app/shared/src/commonMain/kotlin/sample.kmp.app/AppSetup.kt
@@ -39,7 +39,7 @@ fun initializeSentry() {
 /** Returns a shared options configuration */
 private fun optionsConfiguration(): OptionsConfiguration {
     return {
-        it.dsn = "https://26ba9de3c0c247f4b2c3e4ee646f2ebb@o1249351.ingest.sentry.io/6587139"
+        it.dsn = "https://83f281ded2844eda83a8a413b080dbb9@o447951.ingest.sentry.io/5903800"
         it.attachStackTrace = true
         it.attachThreads = true
         it.attachScreenshot = true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,11 +5,13 @@ pluginManagement {
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
+}
 
-    plugins {
-        kotlin("multiplatform").version(extra["kotlin.version"] as String)
-        kotlin("native.cocoapods").version(extra["kotlin.version"] as String)
-        id("org.jetbrains.compose").version(extra["compose.version"] as String)
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        google()
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,4 +24,4 @@ KMP App with targets:
  */
 include("sentry-samples:kmp-app:shared")
 include("sentry-samples:kmp-app:androidApp")
-include("sentry-samples:kmp-app:desktopApp")
+// include("sentry-samples:kmp-app:desktopApp")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ pluginManagement {
 
     plugins {
         kotlin("multiplatform").version(extra["kotlin.version"] as String)
+        kotlin("native.cocoapods").version(extra["kotlin.version"] as String)
         id("org.jetbrains.compose").version(extra["compose.version"] as String)
     }
 }
@@ -24,4 +25,4 @@ KMP App with targets:
  */
 include("sentry-samples:kmp-app:shared")
 include("sentry-samples:kmp-app:androidApp")
-// include("sentry-samples:kmp-app:desktopApp")
+include("sentry-samples:kmp-app:desktopApp")


### PR DESCRIPTION
this PR should fix most issues regarding the build and bump versions of Kotlin and Multiplatform especially #44

additionally, I confirmed the correctness of the artifacts by publishing them on [mymavenrepo](https://mymavenrepo.com/) and testing the SDK in sample apps. Here is the published repo: https://mymavenrepo.com/repo/IxbzFmjbPjBH4llKSvgl/

testing can be done through 
 - adding the repository: `maven {
            url = uri("https://mymavenrepo.com/repo/IxbzFmjbPjBH4llKSvgl/")
        }`
 - importing the dependency in gradle for example: `api("io.sentry:sentry-kotlin-multiplatform:0.0.1")`