### PR TITLE
fix: beforeBreadcrumb hook

### DIFF
--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
@@ -29,4 +29,10 @@ internal fun CocoaSentryOptions.applyCocoaBaseOptions(options: SentryOptions) {
     this.beforeSend = { event ->
         dropKotlinCrashEvent(event as NSExceptionSentryEvent?) as SentryEvent?
     }
+    this.beforeBreadcrumb = { cocoaBreadcrumb ->
+        cocoaBreadcrumb
+            ?.toKmpBreadcrumb()
+            .apply { this?.let { options.beforeBreadcrumb?.invoke(it) } }
+            ?.toCocoaBreadcrumb()
+    }
 }

--- a/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
+++ b/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
@@ -21,4 +21,10 @@ internal fun JvmSentryOptions.applyJvmBaseOptions(options: SentryOptions) {
     this.isDebug = options.debug
     this.sessionTrackingIntervalMillis = options.sessionTrackingIntervalMillis
     this.isEnableAutoSessionTracking = options.enableAutoSessionTracking
+    this.setBeforeBreadcrumb { jvmBreadcrumb, _ ->
+        jvmBreadcrumb
+            .toKmpBreadcrumb()
+            .apply { options.beforeBreadcrumb?.invoke(this) }
+            .toJvmBreadcrumb()
+    }
 }


### PR DESCRIPTION
for some reason the beforeBreadcrumb calls inside the option extensions got removed somewhere during a merge in the past