### PR TITLE
feat: more sdk options and sentry functions

### DIFF
--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
@@ -58,8 +58,8 @@ internal actual object SentryBridge {
         SentrySDK.addBreadcrumb(breadcrumb.toCocoaBreadcrumb())
     }
 
-    actual fun setUser(user: User) {
-        SentrySDK.setUser(user.toCocoaUser())
+    actual fun setUser(user: User?) {
+        SentrySDK.setUser(user?.toCocoaUser())
     }
 
     actual fun close() {

--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
@@ -1,9 +1,13 @@
 package io.sentry.kotlin.multiplatform
 
 import cocoapods.Sentry.SentrySDK
+import io.sentry.kotlin.multiplatform.extensions.toCocoaBreadcrumb
+import io.sentry.kotlin.multiplatform.extensions.toCocoaUser
 import io.sentry.kotlin.multiplatform.extensions.toCocoaUserFeedback
 import io.sentry.kotlin.multiplatform.nsexception.asNSException
+import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import io.sentry.kotlin.multiplatform.protocol.SentryId
+import io.sentry.kotlin.multiplatform.protocol.User
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
 import platform.Foundation.NSError
 import platform.Foundation.NSException
@@ -48,6 +52,14 @@ internal actual object SentryBridge {
 
     actual fun configureScope(scopeCallback: ScopeCallback) {
         SentrySDK.configureScope(configureScopeCallback(scopeCallback))
+    }
+
+    actual fun addBreadcrumb(breadcrumb: Breadcrumb) {
+        SentrySDK.addBreadcrumb(breadcrumb.toCocoaBreadcrumb())
+    }
+
+    actual fun setUser(user: User) {
+        SentrySDK.setUser(user.toCocoaUser())
     }
 
     actual fun close() {

--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
@@ -28,6 +28,8 @@ internal fun CocoaSentryOptions.applyCocoaBaseOptions(options: SentryOptions) {
     this.debug = options.debug
     this.sessionTrackingIntervalMillis = options.sessionTrackingIntervalMillis.convert()
     this.enableAutoSessionTracking = options.enableAutoSessionTracking
+    this.maxAttachmentSize = options.maxAttachmentSize.convert()
+    this.maxBreadcrumbs = options.maxBreadcrumbs.convert()
     this.beforeSend = { event ->
         dropKotlinCrashEvent(event as NSExceptionSentryEvent?) as SentryEvent?
 
@@ -53,6 +55,6 @@ internal fun CocoaSentryOptions.applyCocoaBaseOptions(options: SentryOptions) {
     PrivateSentrySDKOnly.setSdkName(options.sdk.name, options.sdk.version)
     this.beforeBreadcrumb = { cocoaBreadcrumb ->
         cocoaBreadcrumb?.toKmpBreadcrumb()
-            .apply { this?.let { options.beforeBreadcrumb?.invoke(it) } }?.toCocoaBreadcrumb()
+            ?.let { options.beforeBreadcrumb?.invoke(it) }?.toCocoaBreadcrumb()
     }
 }

--- a/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
+++ b/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
@@ -1,8 +1,12 @@
 package io.sentry.kotlin.multiplatform
 
 import io.sentry.Sentry
+import io.sentry.kotlin.multiplatform.extensions.toJvmBreadcrumb
+import io.sentry.kotlin.multiplatform.extensions.toJvmUser
 import io.sentry.kotlin.multiplatform.extensions.toJvmUserFeedback
+import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import io.sentry.kotlin.multiplatform.protocol.SentryId
+import io.sentry.kotlin.multiplatform.protocol.User
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
 
 internal expect fun initSentry(context: Context? = null, configuration: OptionsConfiguration)
@@ -43,6 +47,14 @@ internal actual object SentryBridge {
 
     actual fun configureScope(scopeCallback: ScopeCallback) {
         Sentry.configureScope(configureScopeCallback(scopeCallback))
+    }
+
+    actual fun addBreadcrumb(breadcrumb: Breadcrumb) {
+        Sentry.addBreadcrumb(breadcrumb.toJvmBreadcrumb())
+    }
+
+    actual fun setUser(user: User) {
+        Sentry.setUser(user.toJvmUser())
     }
 
     actual fun close() {

--- a/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
+++ b/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
@@ -53,8 +53,8 @@ internal actual object SentryBridge {
         Sentry.addBreadcrumb(breadcrumb.toJvmBreadcrumb())
     }
 
-    actual fun setUser(user: User) {
-        Sentry.setUser(user.toJvmUser())
+    actual fun setUser(user: User?) {
+        Sentry.setUser(user?.toJvmUser())
     }
 
     actual fun close() {

--- a/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
+++ b/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
@@ -28,10 +28,9 @@ internal fun JvmSentryOptions.applyJvmBaseOptions(options: SentryOptions) {
     this.isDebug = options.debug
     this.sessionTrackingIntervalMillis = options.sessionTrackingIntervalMillis
     this.isEnableAutoSessionTracking = options.enableAutoSessionTracking
+    this.maxAttachmentSize = options.maxAttachmentSize
+    this.maxBreadcrumbs = options.maxBreadcrumbs
     this.setBeforeBreadcrumb { jvmBreadcrumb, _ ->
-        jvmBreadcrumb
-            .toKmpBreadcrumb()
-            .apply { options.beforeBreadcrumb?.invoke(this) }
-            .toJvmBreadcrumb()
+        options.beforeBreadcrumb?.invoke(jvmBreadcrumb.toKmpBreadcrumb())?.toJvmBreadcrumb()
     }
 }

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
@@ -1,6 +1,8 @@
 package io.sentry.kotlin.multiplatform
 
+import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import io.sentry.kotlin.multiplatform.protocol.SentryId
+import io.sentry.kotlin.multiplatform.protocol.User
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
 
 internal expect object SentryBridge {
@@ -20,6 +22,10 @@ internal expect object SentryBridge {
     fun configureScope(scopeCallback: ScopeCallback)
 
     fun captureUserFeedback(userFeedback: UserFeedback)
+
+    fun addBreadcrumb(breadcrumb: Breadcrumb)
+
+    fun setUser(user: User)
 
     fun close()
 }

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
@@ -25,7 +25,7 @@ internal expect object SentryBridge {
 
     fun addBreadcrumb(breadcrumb: Breadcrumb)
 
-    fun setUser(user: User)
+    fun setUser(user: User?)
 
     fun close()
 }

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
@@ -1,6 +1,8 @@
 package io.sentry.kotlin.multiplatform
 
+import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import io.sentry.kotlin.multiplatform.protocol.SentryId
+import io.sentry.kotlin.multiplatform.protocol.User
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
 
 typealias ScopeCallback = (Scope) -> Unit
@@ -85,6 +87,24 @@ object Sentry {
      */
     fun configureScope(scopeCallback: ScopeCallback) {
         SentryBridge.configureScope(scopeCallback)
+    }
+
+    /**
+     * Adds a breadcrumb to the current Scope.
+     *
+     * @param breadcrumb The breadcrumb to add.
+     */
+    fun addBreadcrumb(breadcrumb: Breadcrumb) {
+        SentryBridge.addBreadcrumb(breadcrumb)
+    }
+
+    /**
+     * Sets the user to the current scope.
+     *
+     * @param user The user to set.
+     */
+    fun setUser(user: User) {
+        SentryBridge.setUser(user)
     }
 
     /**

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
@@ -103,7 +103,7 @@ object Sentry {
      *
      * @param user The user to set.
      */
-    fun setUser(user: User) {
+    fun setUser(user: User?) {
         SentryBridge.setUser(user)
     }
 

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryOptions.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryOptions.kt
@@ -56,8 +56,14 @@ open class SentryOptions {
     var attachScreenshot = false
 
     /** Hook that is triggered before a breadcrumb is sent to Sentry */
-    var beforeBreadcrumb: ((Breadcrumb) -> Breadcrumb)? = null
+    var beforeBreadcrumb: ((Breadcrumb) -> Breadcrumb?)? = null
 
     /** Information about the Sentry SDK that generated this event. */
     var sdk: SdkVersion = SdkVersion(BuildKonfig.SENTRY_KOTLIN_MULTIPLATFORM_SDK_NAME, BuildKonfig.VERSION_NAME)
+
+    /** This variable controls the total amount of breadcrumbs that should be captured. Default is 100. */
+    var maxBreadcrumbs = 100
+
+    /** This variable controls the max attachment size in bytes */
+    var maxAttachmentSize: Long = 20 * 1024 * 1024
 }

--- a/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
+++ b/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
@@ -63,5 +63,4 @@ class SentryOptionsTest {
 
         assertEquals(null, modifiedBreadcrumb)
     }
-
 }

--- a/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
+++ b/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
@@ -43,4 +43,25 @@ class SentryOptionsTest {
 
         assertEquals(expectedBreadcrumb, modifiedBreadcrumb)
     }
+
+    @Test
+    fun `Breadcrumb can be dropped via beforeBreadcrumb hook`() {
+        val options = SentryOptions()
+
+        fun mockInit(configuration: (SentryOptions) -> Unit) {
+            configuration.invoke(options)
+        }
+
+        mockInit {
+            it.beforeBreadcrumb = { breadcrumb ->
+                breadcrumb.message = "message"
+                null
+            }
+        }
+
+        val modifiedBreadcrumb = options.beforeBreadcrumb?.invoke(Breadcrumb())
+
+        assertEquals(null, modifiedBreadcrumb)
+    }
+
 }


### PR DESCRIPTION
While preparing the sentry docs for kmp I noticed some things that are missing in the sdk which can be helpful for users and was quick to implement.

 - Sentry.addBreadcrumb
 - Sentry.setUser
 - maxAttachmentSize
 - maxBreadcrumbs
 - beforeBreadcrumb can now drop breadcrumbs (return null)