### PR TITLE
feat(craft): kmp configuration to .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -11,6 +11,9 @@ targets:
       distDirRegex: /^(sentry-android-|.*-android).*$/
       fileReplaceeRegex: /\d\.\d\.\d(-\w+(\.\d)?)?(-SNAPSHOT)?/
       fileReplacerStr: release.aar
+    kmp:
+      rootDistDirRegex: /^(?!.*(?:jvm|android|ios|watchos|tvos|macos)).*$/
+      appleDistDirRegex: /(ios|watchos|tvos|macos)/
   - name: github
   - name: registry
     sdks:

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: 0.33.2
+minVersion: 1.2.0
 changelogPolicy: auto
 targets:
   - name: maven


### PR DESCRIPTION
Adds the kmp configuration needed for a craft release:
 - rootDistDir regex: matches if it's a root directory, meaning it has no "platform" identifiers.
 - appleDistDir regex: matches directories of apple platforms since those contain .klib files that need to be handled differently by craft

minVersion: [1.2.0](https://github.com/getsentry/craft/releases/tag/1.2.0) 