### PR TITLE
chore: remove other sdks in .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -18,17 +18,4 @@ targets:
   - name: registry
     sdks:
       maven:io.sentry:sentry-kotlin-multiplatform:
-      maven:io.sentry:sentry-kotlin-multiplatform-android:
-      maven:io.sentry:sentry-kotlin-multiplatform-jvm:
-      maven:io.sentry:sentry-kotlin-multiplatform-iosarm64:
-      maven:io.sentry:sentry-kotlin-multiplatform-iosx64:
-      maven:io.sentry:sentry-kotlin-multiplatform-iossimulatorarm64:
-      maven:io.sentry:sentry-kotlin-multiplatform-macosx64:
-      maven:io.sentry:sentry-kotlin-multiplatform-macosArm64:
-      maven:io.sentry:sentry-kotlin-multiplatform-watchosarm32:
-      maven:io.sentry:sentry-kotlin-multiplatform-watchosarm64:
-      maven:io.sentry:sentry-kotlin-multiplatform-watchosx64:
-      maven:io.sentry:sentry-kotlin-multiplatform-tvosarm64:
-      maven:io.sentry:sentry-kotlin-multiplatform-tvosx64:
-      maven:io.sentry:sentry-kotlin-multiplatform-tvossimulatorarm64:
 


### PR DESCRIPTION
Since we only keep track of the "main" package which is `maven:io.sentry:sentry-kotlin-multiplatform`, registering the others in the registry is not needed. We only need to upload them to maven and gh which is already done.

Ref: [#106](https://github.com/getsentry/sentry-release-registry/pull/106)