### PR TITLE
fix: Android init crash on API level 23 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix: crash on Android API levels 23 and below ([#61](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/61))
+
 ## 0.0.2
 
 ### Various fixes & improvements

--- a/sentry-kotlin-multiplatform/build.gradle.kts
+++ b/sentry-kotlin-multiplatform/build.gradle.kts
@@ -51,10 +51,7 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation(Config.Libs.sentryAndroid) {
-                    // avoid duplicate dependencies since we depend on commonJvmMain
-                    exclude("io.sentry", "sentry")
-                }
+                implementation(Config.Libs.sentryAndroid)
             }
         }
         val androidUnitTest by getting


### PR DESCRIPTION
Fixes #60 

Reason is that on API 23 and below `SentryAndroid` depends on some `Sentry` functions internally so that's why we cannot exclude it.