### PR TITLE
feat: improve Objc/Swift experience with HiddenFromObjc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 0.0.3
+## Unreleased
 
 ### Features
 
 - Improve Objc/Swift experience with @HiddenFromObjc ([#62](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/62))
+
+## 0.0.3
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.0.3
 
+### Features
+
+- Improve Objc/Swift experience with @HiddenFromObjc ([#62](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/62))
+
 ### Fixes
 
 - fix: crash on Android API levels 23 and below ([#61](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/61))

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
     <h1>Experimental Sentry SDK for Kotlin Multiplatform</h1>
 </p>
 
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
+
 This project is an experimental SDK for Kotlin Multiplatform.
 This SDK is a wrapper around different platforms such as JVM, Android, iOS, macOS, watchOS, tvOS that can be used on Kotlin Multiplatform.
-
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 
 | Packages                                | Maven Central
 |-----------------------------------------| -------

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
     <h1>Experimental Sentry SDK for Kotlin Multiplatform</h1>
 </p>
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
-
 This project is an experimental SDK for Kotlin Multiplatform.
 This SDK is a wrapper around different platforms such as JVM, Android, iOS, macOS, watchOS, tvOS that can be used on Kotlin Multiplatform.
+
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 
 | Packages                                | Maven Central
 |-----------------------------------------| -------

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 This project is an experimental SDK for Kotlin Multiplatform.
 This SDK is a wrapper around different platforms such as JVM, Android, iOS, macOS, watchOS, tvOS that can be used on Kotlin Multiplatform.
 
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
+
 | Packages                                | Maven Central
 |-----------------------------------------| -------
 | sentry-kotlin-multiplatform                          | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-kotlin-multiplatform/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-kotlin-multiplatform)

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
@@ -4,6 +4,8 @@ import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import io.sentry.kotlin.multiplatform.protocol.SentryId
 import io.sentry.kotlin.multiplatform.protocol.User
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 
 typealias ScopeCallback = (Scope) -> Unit
 typealias OptionsConfiguration = (SentryOptions) -> Unit
@@ -19,6 +21,8 @@ object Sentry {
      * @param context: The context (used for retrieving Android Context)
      * @param configuration Options configuration handler.
      */
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     fun init(context: Context, configuration: OptionsConfiguration) {
         SentryBridge.init(context, configuration)
     }

--- a/sentry-samples/kmp-app/iosApp/iosApp/iOSApp.swift
+++ b/sentry-samples/kmp-app/iosApp/iosApp/iOSApp.swift
@@ -3,15 +3,15 @@ import shared
 
 @main
 struct iOSApp: App {
-    let sentry = Sentry()
-
+    let sentry = Sentry.shared
+    
     init() {
         // Initialize Sentry using shared code
         AppSetupKt.initializeSentry()
 
         // Shared scope across all platforms
         AppSetupKt.configureSentryScope()
-
+        
         // Add platform specific scope in addition to the shared scope
         sentry.configureScope { scope in
             scope.setContext(key: "iOS Context", value: [


### PR DESCRIPTION
Add `@HiddenFromObjc` annotation to hide `init` with context from Cocoa targets.
This is very useful if we want to have certain things hidden to make the Swift experience better in general

https://kotlinlang.org/docs/native-objc-interop.html 