### PR TITLE
Automatically disable `io.sentry.auto-init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- feat: automatically disable `io.sentry.auto-init` ([#93](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/93))
+
 ### Improvements
 
 - ref: improve samples & add SPM docs ([#82](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/82))

--- a/sentry-kotlin-multiplatform/src/androidMain/AndroidManifest.xml
+++ b/sentry-kotlin-multiplatform/src/androidMain/AndroidManifest.xml
@@ -3,9 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="io.sentry.kotlin.multiplatform">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <application>
         <provider
             android:name="io.sentry.android.core.SentryInitProvider"

--- a/sentry-kotlin-multiplatform/src/androidMain/AndroidManifest.xml
+++ b/sentry-kotlin-multiplatform/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.sentry.kotlin.multiplatform">
-  <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-\</manifest>
+    xmlns:tools="http://schemas.android.com/tools"
+    package="io.sentry.kotlin.multiplatform">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <application>
+        <provider
+            android:name="io.sentry.android.core.SentryInitProvider"
+            android:authorities="${applicationId}.SentryInitProvider"
+            android:exported="false"
+            tools:node="remove"/>
+    </application>
+
+</manifest>

--- a/sentry-samples/kmp-app-cocoapods/androidApp/src/main/AndroidManifest.xml
+++ b/sentry-samples/kmp-app-cocoapods/androidApp/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:name=".SentryApplication">
-        <meta-data android:name="io.sentry.auto-init" android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/sentry-samples/kmp-app-mvvm-di/androidApp/src/main/AndroidManifest.xml
+++ b/sentry-samples/kmp-app-mvvm-di/androidApp/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="DataExtractionRules">
-        <meta-data android:name="io.sentry.auto-init" android:value="false" />
         <activity
             android:name="sentry.kmp.demo.android.MainActivity"
             android:exported="true">

--- a/sentry-samples/kmp-app-spm/androidApp/src/main/AndroidManifest.xml
+++ b/sentry-samples/kmp-app-spm/androidApp/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:name=".SentryApplication">
-        <meta-data android:name="io.sentry.auto-init" android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true">


### PR DESCRIPTION
Introduces #89 so the user doesn't have to manually disable the init through AndroidManifest.