### PR TITLE
chore: update docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,216 +8,51 @@
     <h1>Experimental Sentry SDK for Kotlin Multiplatform</h1>
 </p>
 
-This project is an experimental SDK for Kotlin Multiplatform.
-This SDK is a wrapper around different platforms such as JVM, Android, iOS, macOS, watchOS, tvOS that can be used on Kotlin Multiplatform.
+_Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write
+better software faster, so we can get back to enjoying technology. If you want to join
+us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
+
+This SDK is a wrapper around different platforms such as JVM, Android, iOS, macOS, watchOS, tvOS
+that can be used on Kotlin Multiplatform.
 
 [![Kotlin](https://img.shields.io/badge/Kotlin-1.8.0-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 
-| Packages                                | Maven Central
-|-----------------------------------------| -------
-| sentry-kotlin-multiplatform                          | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-kotlin-multiplatform/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-kotlin-multiplatform)
+| Packages                    | Maven Central                                                                                                                                                                                                
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| sentry-kotlin-multiplatform | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-kotlin-multiplatform/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-kotlin-multiplatform) 
 
 ## Supported Platforms
 
-| Target Platform | Target preset |
-|:-------------:|-------------|
-| Android     | <ul><li>`android`</li></ul> |
-| Kotlin/JVM  | <ul><li>`jvm`</li></ul>
-| iOS         | <ul><li>`iosArm64`</li><li>`iosX64`</li><li>`iosSimulatorArm64`</li></ul>|
-| macOS       | <ul><li>`macosArm64`</li><li>`macosX64`</ul>|
-| watchOS     | <ul><li>`watchosArm32`</li><li>`watchosArm64`</li><li>`watchosX64`</li><li>`watchosSimulatorArm64`</li></ul>|
-| tvOS        | <ul><li>`tvosArm64`</li><li>`tvosX64`</li><li>`tvosSimulatorArm64`</li></ul>|
+| Target Platform | Target preset                                                                                                |
+|:---------------:|--------------------------------------------------------------------------------------------------------------|
+|     Android     | <ul><li>`android`</li></ul>                                                                                  |
+|   Kotlin/JVM    | <ul><li>`jvm`</li></ul>                                                                                      
+|       iOS       | <ul><li>`iosArm64`</li><li>`iosX64`</li><li>`iosSimulatorArm64`</li></ul>                                    |
+|      macOS      | <ul><li>`macosArm64`</li><li>`macosX64`</ul>                                                                 |
+|     watchOS     | <ul><li>`watchosArm32`</li><li>`watchosArm64`</li><li>`watchosX64`</li><li>`watchosSimulatorArm64`</li></ul> |
+|      tvOS       | <ul><li>`tvosArm64`</li><li>`tvosX64`</li><li>`tvosSimulatorArm64`</li></ul>                                 |
 
-## Configure Repository
+## Usage
 
-The Kotlin Multiplatform SDK is available on `mavenCentral`. You can declare this repository in your build script as follows:
+For detailed usage, check out the Resources section below.
 
-```gradle
-repositories {
-  mavenCentral()
-}
-```
+## Samples
 
-## Add dependency
-For a multiplatform project, you need to add the sentry-kotlin-multiplatform artifact to the `commonMain` source set:
+For detailed information on how to build and run the samples, check out our `README.md` in the
+[sentry-samples](https://github.com/getsentry/sentry-kotlin-multiplatform/tree/main/sentry-samples)
+folder.
 
-```Kotlin
-val commonMain by getting {
-  dependencies {
-    api("io.sentry:sentry-kotlin-multiplatform:<version>")
-  }
-}
-```
+## Contribution
 
-### Cocoa
+Please see
+the [contribution guide](https://github.com/getsentry/sentry-kotlin-multiplatform/blob/main/CONTRIBUTING.md)
+before contributing
 
-If you are targeting Apple platforms (iOS, macOS, watchOS, tvOS), then you can use CocoaPods to include [Sentry Cocoa](https://github.com/getsentry/sentry-cocoa) into this SDK.
-One way to achieve this is to include the Sentry Cocoa SDK via the Kotlin CocoaPods extension. Be aware that your Sentry Cocoa version has to match the version used in the KMP SDK.
+# Resources
 
-```gradle
-cocoapods {
-  // ...
-  
-  // Make sure Sentry Cocoa in your project matches this version
-  pod("Sentry", "~> 8.4.0")
-
-  framework {
-    baseName = "shared"
-
-    // Export the SDK in order to be able to access it directly in the iOS project
-    export("io.sentry:sentry-kotlin-multiplatform:<version>")
-  }
-}
-```
-
-### Swift Package Manager
-
-Alternatively you can use the Swift Package Manager to include the Sentry Cocoa SDK into this SDK.
-Open your iOS app in Xcode and open File > Add Packages. Then add the SDK by entering the git repo url in the top right search field:
-`https://github.com/getsentry/sentry-cocoa.git`
-
-After adding the package, you need to add the following to your shared `build.gradle.kts`:
-
-```gradle
-listOf(
-    iosX64(),
-    iosArm64(),
-    iosSimulatorArm64(),
-    // ... other Apple targets
-).forEach {
-    it.binaries.framework {
-        baseName = "shared"
-        isStatic = true
-        
-        // Export the SDK in order to be able to access it directly in the iOS project
-        export("io.sentry:sentry-kotlin-multiplatform:<version>")
-    }
-}
-```
-
-## Initialization
-
-There are two main strategies for initializing the SDK:
-  - Shared initializer
-  - Platform-specific initializers
-
-Shared initializer will initialize the SDK in your shared codebase but you will use the same configuration options for all platforms. 
-
-Platform-specific initializers initialize the SDK directly in the target platform. The benefit is being able to customize the configuration options specific to the platforms.
-
-It is also possible to mix those two strategies based on your needs and project setup.
-
-## Prerequisites (Android-only)
-
-Both of the strategies require disabling auto-init on Android to not clash with the `ContentProvider`, which auto-initializes the Sentry Android SDK. To do so, add the following to the `AndroidManifest.xml` file under your `androidMain` source set:
-
-```xml
-<application>
-    <meta-data android:name="io.sentry.auto-init" android:value="false" />
-</application>
-```
-
-## Shared Initializer
-
-Create a Kotlin file in your commonMain e.g. `AppSetup.kt` or however you want to call it and create a function that will initialize the SDK.
-
-```Kotlin
-import io.sentry.kotlin.multiplatform.Context
-import io.sentry.kotlin.multiplatform.Sentry
-import io.sentry.kotlin.multiplatform.OptionsConfiguration
-
-// The context is needed for Android initializations
-fun initializeSentry(context: Context) {
-  Sentry.init(context, optionsConfiguration())
-}
-
-fun initializeSentry() {
-  Sentry.init(optionsConfiguration())
-}
-
-private fun optionsConfiguration(): OptionsConfiguration = {
-  it.dsn = "__DSN__"
-}
-
-```
-
-Now call this function in an early lifecycle stage in your platforms.
-
-### Android
-```Kotlin
-import your.kmp.app.initializeSentry
-
-class YourApplication : Application() {
-  override fun onCreate() {
-    super.onCreate()
-      // Make sure to add the context!
-      initializeSentry(this)
-   }
-}
-```
-
-### Cocoa
-
-```Swift
-import shared
-
-class AppDelegate: NSObject, UIApplicationDelegate {
-    func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
-    ) -> Bool {
-        AppSetupKt.initializeSentry()
-        return true        
-    }
-}
-```
-
-## Platform-Specific Initializers
-### Android
-
-```Kotlin
-import io.sentry.kotlin.multiplatform.Sentry
-
-class YourApplication : Application() {
-  override fun onCreate() {
-    super.onCreate()
-      // Make sure to add the context!
-      Sentry.init(this) {
-        it.dsn = "___DSN___"
-      }
-   }
-}
-```
-
-### Cocoa
-```Swift
-import shared
-
-class AppDelegate: NSObject, UIApplicationDelegate {
-    func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
-    ) -> Bool {
-        Sentry.shared.doInit() { options in
-          options.dsn = "__DSN__"
-        }
-        return true        
-    }
-}
-```
-
-## Debug Symbols for Apple targets
-
-A dSYM upload is required for Sentry to symbolicate your crash logs for viewing. The symbolication process unscrambles Apple’s crash logs to reveal the function, variables, file names, and line numbers of the crash. The dSYM file can be uploaded through the sentry-cli tool or through a Fastlane action. Please visit our [sentry.io guide](https://docs.sentry.io/platforms/apple/dsym/) to get started on uploading debug symbols.
-
- ## Troubleshooting
-
- `WARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
-    Consider adding the following to ~/.profile:
-    export LANG=en_US.UTF-8`
-
-  This is a known problem and can easily be fixed as described in this [Stack Overflow post](https://stackoverflow.com/a/69395720)
-
- ## Contribution
-
- Please see the [contribution guide](https://github.com/getsentry/sentry-kotlin-multiplatform/blob/main/CONTRIBUTING.md) before contributing
+* [![Kotlin Multiplatform Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg?label=documentation)](https://docs.sentry.io/platforms/kotlin-multiplatform/)
+* [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-kotlin-multiplatform.svg)](https://github.com/getsentry/sentry-kotlin-multiplatform/discussions)
+* [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)
+* [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
+* [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-sentry-green.svg)](https://github.com/getsentry/.github/blob/master/CODE_OF_CONDUCT.md)
+* [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ that can be used on Kotlin Multiplatform.
 
 ## Usage
 
-For detailed usage, check out the Resources section below.
+For detailed usage, check out the [Kotlin Multiplatform Documentation](https://docs.sentry.io/platforms/kotlin-multiplatform/).
 
 ## Samples
 


### PR DESCRIPTION
Ref: #90 

Removes init and configuration doc and instead refers to the sentry-doc documentation in `Resources`

#skip-changelog