### PR TITLE
Fix get version for cocoa in sentry deps bot

### DIFF
--- a/scripts/update-cocoa.sh
+++ b/scripts/update-cocoa.sh
@@ -16,30 +16,34 @@ if ! [[ $config_content =~ $config_regex ]]; then
     exit 1
 fi
 
-config_bash_rematch=$BASH_REMATCH
+config_whole_match=${BASH_REMATCH[0]}
+config_var_name=${BASH_REMATCH[1]}
+config_version=${BASH_REMATCH[2]}
 
 if ! [[ $podspec_content =~ $podspec_regex ]]; then
     echo "Failed to find the Cocoa version in $podspec_file"
     exit 1
 fi
 
-podspec_bash_rematch=$BASH_REMATCH
+podspec_whole_match=${BASH_REMATCH[0]}
+podspec_var_name=${BASH_REMATCH[1]}
 
 case $1 in
 get-version)
-    echo ${BASH_REMATCH[2]}
+    # We only require to return the version number of one of the files
+    echo ${config_version}
     ;;
 get-repo)
     echo "https://github.com/getsentry/sentry-cocoa.git"
     ;;
 set-version)
     # Update the version in the config file
-    newValue="${config_bash_rematch[1]}\"$2"\"
-    echo "${config_content/${config_bash_rematch[0]}/$newValue}" >$config_file
+    newValue="${config_var_name}\"$2"\"
+    echo "${config_content/${config_whole_match}/$newValue}" >$config_file
 
     # Update the version in the podspec file
-    newValue="${podspec_bash_rematch[1]}'$2'"
-    echo "${podspec_content/${podspec_bash_rematch[0]}/$newValue}" >$podspec_file
+    newValue="${podspec_var_name}'$2'"
+    echo "${podspec_content/${podspec_whole_match}/$newValue}" >$podspec_file
     ;;
 *)
     echo "Unknown argument $1"

--- a/scripts/update-cocoa.sh
+++ b/scripts/update-cocoa.sh
@@ -27,7 +27,7 @@ podspec_bash_rematch=$BASH_REMATCH
 
 case $1 in
 get-version)
-    echo ${podspec_bash_rematch[2]}
+    echo ${BASH_REMATCH[2]}
     ;;
 get-repo)
     echo "https://github.com/getsentry/sentry-cocoa.git"


### PR DESCRIPTION
## :scroll: Description

Fixes fetching and setting of the version which causes it to fail for cocoa: https://github.com/getsentry/sentry-kotlin-multiplatform/actions/runs/6665350889/job/18114812485

#skip-changelog

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Locally ran the script and verified the version

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps