### PR TITLE
chore: fix publish by adding -all.jar file

### DIFF
--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -17,7 +17,7 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
             renameModule(project.name, version = version)
         }
         // The current Kotlin version doesn't generate this *-all.jar anymore.
-        // This is a placeholder for backwards compatibility with craft.
+        // This is a placeholder for backwards compatibility with craft until we fix it there directly.
         from("build${sep}libs") {
             include("${project.name}-$version")
             rename {

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -1,8 +1,6 @@
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.file.CopySpec
-import org.gradle.jvm.tasks.Jar
 import java.io.File
 
 private object Consts {

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -18,7 +18,7 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
         from("build${sep}publications${sep}kotlinMultiplatform") {
             renameModule(project.name, version = version)
         }
-        // The current kotlin version doesn't generate this *-all.jar anymore.
+        // The current Kotlin version doesn't generate this *-all.jar anymore.
         // This is a placeholder for backwards compatibility with craft.
         from("build${sep}libs") {
             include("${project.name}*javadoc*")

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -1,6 +1,8 @@
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.file.CopySpec
+import org.gradle.jvm.tasks.Jar
 import java.io.File
 
 private object Consts {
@@ -15,6 +17,14 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
     this.getByName("main").contents {
         from("build${sep}publications${sep}kotlinMultiplatform") {
             renameModule(project.name, version = version)
+        }
+        // The current kotlin version doesn't generate this *-all.jar anymore.
+        // This is a placeholder for backwards compatibility with craft.
+        from("build${sep}libs") {
+            include("${project.name}*javadoc*")
+            rename {
+                it.replace("$version-javadoc", "$version-all")
+            }
         }
         from("build${sep}kotlinToolingMetadata") {
             rename {

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -21,9 +21,9 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
         // The current Kotlin version doesn't generate this *-all.jar anymore.
         // This is a placeholder for backwards compatibility with craft.
         from("build${sep}libs") {
-            include("${project.name}*javadoc*")
+            include("${project.name}-$version")
             rename {
-                it.replace("$version-javadoc", "$version-all")
+                it.replace("$version", "$version-all")
             }
         }
         from("build${sep}kotlinToolingMetadata") {


### PR DESCRIPTION
Fixes the publish on craft which expects a `*-all.jar` file but this is not created anymore in the current Kotlin version.

So this creates a placeholder jar file until we can fix the craft implementation directly.

#skip-changelog