### PR TITLE
chore: fix cinterop problem for publish

### DIFF
--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -185,7 +185,8 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
 
 private fun CopySpec.fromKlib(projectName: String, target: String, version: String) {
     val pos = projectName.length
-    from("build${sep}libs${sep}${target}${sep}main") {
+    from("build${sep}classes${sep}kotlin${sep}${target}${sep}main${sep}cinterop") {
+        include("*.klib")
         rename {
             it.replaceRange(pos, pos, "-${target.toLowerCase()}-$version")
         }


### PR DESCRIPTION
fixes the cinterop part of the publish

cinterop klib files are now generated in another build folder in the current Kotlin version that's why they weren't included in the dist

#skip-changelog