### PR TITLE
Add isCrashedLastRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Add isCrashedLastRun ([#186](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/186))
+  - You can use it with `Sentry.isCrashedLastRun()`
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.17.2 to v8.20.0 ([#180](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/180), [#182](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/182))

--- a/sentry-kotlin-multiplatform/api/android/sentry-kotlin-multiplatform.api
+++ b/sentry-kotlin-multiplatform/api/android/sentry-kotlin-multiplatform.api
@@ -84,6 +84,7 @@ public final class io/sentry/kotlin/multiplatform/Sentry {
 	public final fun crash ()V
 	public final fun init (Landroid/content/Context;Lkotlin/jvm/functions/Function1;)V
 	public final fun init (Lkotlin/jvm/functions/Function1;)V
+	public final fun isCrashedLastRun ()Z
 	public final fun setUser (Lio/sentry/kotlin/multiplatform/protocol/User;)V
 }
 

--- a/sentry-kotlin-multiplatform/api/jvm/sentry-kotlin-multiplatform.api
+++ b/sentry-kotlin-multiplatform/api/jvm/sentry-kotlin-multiplatform.api
@@ -81,6 +81,7 @@ public final class io/sentry/kotlin/multiplatform/Sentry {
 	public final fun crash ()V
 	public final fun init (Lio/sentry/kotlin/multiplatform/Context;Lkotlin/jvm/functions/Function1;)V
 	public final fun init (Lkotlin/jvm/functions/Function1;)V
+	public final fun isCrashedLastRun ()Z
 	public final fun setUser (Lio/sentry/kotlin/multiplatform/protocol/User;)V
 }
 

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.apple.kt
@@ -65,6 +65,10 @@ internal actual object SentryBridge {
         SentrySDK.setUser(user?.toCocoaUser())
     }
 
+    actual fun isCrashedLastRun(): Boolean {
+        return SentrySDK.crashedLastRun()
+    }
+
     actual fun close() {
         SentrySDK.close()
     }

--- a/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.jvm.kt
+++ b/sentry-kotlin-multiplatform/src/commonJvmMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.jvm.kt
@@ -57,6 +57,10 @@ internal actual object SentryBridge {
         Sentry.setUser(user?.toJvmUser())
     }
 
+    actual fun isCrashedLastRun(): Boolean {
+        return Sentry.isCrashedLastRun() ?: false
+    }
+
     actual fun close() {
         Sentry.close()
     }

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.kt
@@ -27,5 +27,7 @@ internal expect object SentryBridge {
 
     fun setUser(user: User?)
 
+    fun isCrashedLastRun(): Boolean
+
     fun close()
 }

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryKMP.kt
@@ -118,6 +118,13 @@ public object Sentry {
     }
 
     /**
+     * Returns true if the app crashed during last run.
+     */
+    public fun isCrashedLastRun(): Boolean {
+        return SentryBridge.isCrashedLastRun()
+    }
+
+    /**
      * Throws a RuntimeException, useful for testing.
      */
     public fun crash() {


### PR DESCRIPTION
## :scroll: Description

Adds `isCrashedLastRun`

**Note**: codecov ci fails because I haven't added any test, not sure what the best way to test here is since mocking on KMP is not really a thing yet

## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-kotlin-multiplatform/issues/178

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?
Manually

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps