### PR TITLE
Fix: don't crash app when `applicationContext` is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ pod("Sentry") {
 }
 ```
 
+### Fixes
+
+- Don't crash app when `applicationContext` is not available ([#217](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/217))
+
 ### Enhancements
 
 - Make `setSentryUnhandledExceptionHook` public ([#208](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/208))

--- a/sentry-kotlin-multiplatform/src/androidMain/kotlin/io/sentry/kotlin/multiplatform/SentryInit.android.kt
+++ b/sentry-kotlin-multiplatform/src/androidMain/kotlin/io/sentry/kotlin/multiplatform/SentryInit.android.kt
@@ -5,16 +5,24 @@ import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
+import android.util.Log
 import io.sentry.android.core.SentryAndroid
 import io.sentry.kotlin.multiplatform.extensions.toAndroidSentryOptionsCallback
 
 internal actual fun initSentry(configuration: OptionsConfiguration) {
     val options = SentryOptions()
     configuration.invoke(options)
-    SentryAndroid.init(applicationContext, options.toAndroidSentryOptionsCallback())
-}
 
-internal lateinit var applicationContext: Context
+    val context = applicationContext ?: run {
+        // TODO: add logging later
+        return
+    }
+
+    SentryAndroid.init(context) { sentryOptions ->
+        options.toAndroidSentryOptionsCallback().invoke(sentryOptions)
+    }}
+
+internal var applicationContext: Context? = null
     private set
 
 public actual typealias Context = Context

--- a/sentry-kotlin-multiplatform/src/androidMain/kotlin/io/sentry/kotlin/multiplatform/SentryInit.android.kt
+++ b/sentry-kotlin-multiplatform/src/androidMain/kotlin/io/sentry/kotlin/multiplatform/SentryInit.android.kt
@@ -5,7 +5,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
-import android.util.Log
 import io.sentry.android.core.SentryAndroid
 import io.sentry.kotlin.multiplatform.extensions.toAndroidSentryOptionsCallback
 
@@ -20,7 +19,8 @@ internal actual fun initSentry(configuration: OptionsConfiguration) {
 
     SentryAndroid.init(context) { sentryOptions ->
         options.toAndroidSentryOptionsCallback().invoke(sentryOptions)
-    }}
+    }
+}
 
 internal var applicationContext: Context? = null
     private set

--- a/sentry-kotlin-multiplatform/src/androidUnitTest/kotlin/io/sentry/kotlin/multiplatform/SentryContextProviderTest.kt
+++ b/sentry-kotlin-multiplatform/src/androidUnitTest/kotlin/io/sentry/kotlin/multiplatform/SentryContextProviderTest.kt
@@ -7,6 +7,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class SentryContextProviderTest : BaseSentryTest() {
@@ -22,8 +23,8 @@ class SentryContextProviderTest : BaseSentryTest() {
     class SentryContextOnCreateTest : BaseSentryTest() {
         @Test
         fun `onCreate initializes applicationContext`() {
-            // Simple call to the lateinit applicationContext to make sure it's initialized
-            applicationContext
+            // Simple call to the applicationContext to make sure it's initialized
+            assertNotNull(applicationContext)
         }
     }
 


### PR DESCRIPTION
## :scroll: Description

`lateinit` crashes the application if not set for example when using the Phoenix library

When calling `ProcessPhoenix.triggerRebirth(context)` the app is actually restarted twice and only one the second time the content providers are loaded.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #212 

## :green_heart: How did you test it?
Manual, `SentryContextProviderTest`

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps