### PR TITLE
fix(apple): remove sentry frames from stacktrace (testing only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Remove Sentry frames from stacktrace on Apple targets ([#223](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/223))
+
 ### Features
 
 - Allow initializing the KMP SDK with native options ([#221](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/221))

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.apple.kt
@@ -2,7 +2,9 @@ package io.sentry.kotlin.multiplatform
 
 import NSException.Sentry.SentryEvent
 import PrivateSentrySDKOnly.Sentry.PrivateSentrySDKOnly
+import cocoapods.Sentry.SentryFrame
 import cocoapods.Sentry.SentrySDK
+import cocoapods.Sentry.SentryThread
 import io.sentry.kotlin.multiplatform.extensions.toCocoaBreadcrumb
 import io.sentry.kotlin.multiplatform.extensions.toCocoaUser
 import io.sentry.kotlin.multiplatform.extensions.toCocoaUserFeedback
@@ -12,6 +14,7 @@ import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import io.sentry.kotlin.multiplatform.protocol.SentryId
 import io.sentry.kotlin.multiplatform.protocol.User
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
+import io.sentry.kotlin.multiplatform.SentryStackTraceTrimmer.removeSentryFrames
 import platform.Foundation.NSError
 import platform.Foundation.NSException
 
@@ -26,6 +29,13 @@ internal actual fun SentryPlatformOptions.prepareForInit() {
         // Return early if the user's beforeSend returns null
         if (existingBeforeSend?.invoke(event) == null) {
             return@beforeSend null
+        }
+
+        val threads = event?.threads as? List<SentryThread>
+        threads?.forEach { thread ->
+            thread.stacktrace?.let { stackTrace ->
+                removeSentryFrames(stackTrace)
+            }
         }
 
         val cocoaName = BuildKonfig.SENTRY_COCOA_PACKAGE_NAME

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryBridge.apple.kt
@@ -2,9 +2,9 @@ package io.sentry.kotlin.multiplatform
 
 import NSException.Sentry.SentryEvent
 import PrivateSentrySDKOnly.Sentry.PrivateSentrySDKOnly
-import cocoapods.Sentry.SentryFrame
 import cocoapods.Sentry.SentrySDK
 import cocoapods.Sentry.SentryThread
+import io.sentry.kotlin.multiplatform.SentryStackTraceTrimmer.removeSentryFrames
 import io.sentry.kotlin.multiplatform.extensions.toCocoaBreadcrumb
 import io.sentry.kotlin.multiplatform.extensions.toCocoaUser
 import io.sentry.kotlin.multiplatform.extensions.toCocoaUserFeedback
@@ -14,7 +14,6 @@ import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import io.sentry.kotlin.multiplatform.protocol.SentryId
 import io.sentry.kotlin.multiplatform.protocol.User
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
-import io.sentry.kotlin.multiplatform.SentryStackTraceTrimmer.removeSentryFrames
 import platform.Foundation.NSError
 import platform.Foundation.NSException
 

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmer.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmer.kt
@@ -2,7 +2,6 @@ package io.sentry.kotlin.multiplatform
 
 import cocoapods.Sentry.SentryFrame
 import cocoapods.Sentry.SentryStacktrace
-import cocoapods.Sentry.SentryThread
 import platform.Foundation.NSThread
 
 internal object SentryStackTraceTrimmer {
@@ -22,7 +21,7 @@ internal object SentryStackTraceTrimmer {
 
     private fun trimStackTrace(stacktrace: SentryStacktrace, instructionAddress: String?) {
         val frames = stacktrace.frames as List<SentryFrame>
-        val newFrames = frames.takeWhile { frame -> frame.instructionAddress!= instructionAddress }
+        val newFrames = frames.takeWhile { frame -> frame.instructionAddress != instructionAddress }
         stacktrace.setFrames(newFrames)
     }
 
@@ -30,7 +29,7 @@ internal object SentryStackTraceTrimmer {
         val callStackSymbols = getCallStackSymbols()
         val lastSentryFrameIndex = findLastSentryFrameIndex(callStackSymbols)
 
-        if (lastSentryFrameIndex!= -1) {
+        if (lastSentryFrameIndex != -1) {
             val lastSentryFrame = callStackSymbols[lastSentryFrameIndex]
             val instructionAddress = extractInstructionAddress(lastSentryFrame)
             instructionAddress?.let { address -> trimStackTrace(stacktrace, address) }

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmer.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmer.kt
@@ -1,0 +1,39 @@
+package io.sentry.kotlin.multiplatform
+
+import cocoapods.Sentry.SentryFrame
+import cocoapods.Sentry.SentryStacktrace
+import cocoapods.Sentry.SentryThread
+import platform.Foundation.NSThread
+
+internal object SentryStackTraceTrimmer {
+    private const val SENTRY_FRAME_PACKAGE = "io.sentry.kotlin.multiplatform"
+
+    private fun getCallStackSymbols(): List<String> {
+        return NSThread.callStackSymbols() as? List<String> ?: emptyList()
+    }
+
+    private fun findLastSentryFrameIndex(callStackSymbols: List<String>): Int {
+        return callStackSymbols.indexOfLast { it.contains(SENTRY_FRAME_PACKAGE) }
+    }
+
+    private fun extractInstructionAddress(sentryFrame: String): String? {
+        return sentryFrame.replace(Regex("\\s+"), " ").split(" ")[2].takeIf { it.isNotEmpty() }
+    }
+
+    private fun trimStackTrace(stacktrace: SentryStacktrace, instructionAddress: String?) {
+        val frames = stacktrace.frames as List<SentryFrame>
+        val newFrames = frames.takeWhile { frame -> frame.instructionAddress!= instructionAddress }
+        stacktrace.setFrames(newFrames)
+    }
+
+    fun removeSentryFrames(stacktrace: SentryStacktrace) {
+        val callStackSymbols = getCallStackSymbols()
+        val lastSentryFrameIndex = findLastSentryFrameIndex(callStackSymbols)
+
+        if (lastSentryFrameIndex!= -1) {
+            val lastSentryFrame = callStackSymbols[lastSentryFrameIndex]
+            val instructionAddress = extractInstructionAddress(lastSentryFrame)
+            instructionAddress?.let { address -> trimStackTrace(stacktrace, address) }
+        }
+    }
+}

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmerTest.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmerTest.kt
@@ -1,0 +1,2 @@
+package io.sentry.kotlin.multiplatform
+

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmerTest.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/SentryStackTraceTrimmerTest.kt
@@ -1,2 +1,1 @@
 package io.sentry.kotlin.multiplatform
-


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
### Before fix:
<img width="1139" alt="image" src="https://github.com/getsentry/sentry-kotlin-multiplatform/assets/23364143/e2af8d62-b340-4152-9abd-15c8b02323f9">

### After fix:
<img width="1129" alt="Screenshot 2024-05-16 at 04 15 29" src="https://github.com/getsentry/sentry-kotlin-multiplatform/assets/23364143/0bfbac6d-5981-43c6-a4cf-9ea8a19d2e78">


## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-kotlin-multiplatform/issues/77

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps