### PR TITLE
Update Kotlin version to `1.9.23`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Dependencies
 
+- Bump Kotlin version from v1.9.21 to v1.9.23 ([#250](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/250))
 - Bump Java SDK from v7.9.0 to v7.12.0 ([#236](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/236), [#242](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/242))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7120)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.9.0...7.12.0)

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,7 +1,7 @@
 object Config {
     val agpVersion = "7.4.2"
-    val kotlinVersion = "1.9.21"
-    val composeVersion = "1.5.11"
+    val kotlinVersion = "1.9.23"
+    val composeVersion = "1.6.1"
     val gradleMavenPublishPluginVersion = "0.18.0"
 
     val multiplatform = "multiplatform"


### PR DESCRIPTION
There is a known issue with compiling on xcode `15.3` that is fixed only on Kotlin `1.9.23` and higher.

We are on `1.9.21` and I have to change it to `1.9.23` every time when developing on KMP.

See: https://youtrack.jetbrains.com/issue/KT-65542/Cinterop-tasks-fails-if-Xcode-15.3-is-used

I'm not sure about the backwards compatibility implications but I think it's fine?

@romtsn 