### PR TITLE
feat(plugin): dont use `latest.release` as default for the KMP dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Features
+### Improvements
 
 - Plugin: dont use `latest.release` as default for the KMP dependency ([#262](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/262))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Plugin: dont use `latest.release` as default for the KMP dependency ([#262](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/262))
+
 ### Dependencies
 
 - **Gradle Plugin:** Bump default Cocoa SDK from v8.26.0 to v8.36.0 ([#261](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/261))

--- a/sentry-kotlin-multiplatform-gradle-plugin/build.gradle.kts
+++ b/sentry-kotlin-multiplatform-gradle-plugin/build.gradle.kts
@@ -95,6 +95,11 @@ buildConfig {
         "SentryCocoaVersion",
         provider { "\"${project.property("sentryCocoaVersion")}\"" }
     )
+    buildConfigField(
+        "String",
+        "SentryKmpVersion",
+        provider { "\"${project.property("versionName")}\"" }
+    )
 }
 
 detekt { config.setFrom(rootProject.files("../config/detekt/detekt.yml")) }

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/main/java/io/sentry/kotlin/multiplatform/gradle/SourceSetAutoInstallExtension.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/main/java/io/sentry/kotlin/multiplatform/gradle/SourceSetAutoInstallExtension.kt
@@ -19,10 +19,11 @@ abstract class SourceSetAutoInstallExtension @Inject constructor(project: Projec
     /**
      * Overrides the default Sentry Kotlin Multiplatform SDK dependency version.
      *
-     * Defaults to the latest version of the Sentry Kotlin Multiplatform SDK.
+     * Defaults to the latest version of the Sentry Kotlin Multiplatform SDK which is
+     * the same as the version of the Sentry Gradle Plugin.
      */
     val sentryKmpVersion: Property<String> =
         objects
             .property(String::class.java)
-            .convention("latest.release") // Replace with the actual default version
+            .convention(project.version.toString())
 }

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/main/java/io/sentry/kotlin/multiplatform/gradle/SourceSetAutoInstallExtension.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/main/java/io/sentry/kotlin/multiplatform/gradle/SourceSetAutoInstallExtension.kt
@@ -1,5 +1,6 @@
 package io.sentry.kotlin.multiplatform.gradle
 
+import io.sentry.BuildConfig
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import javax.inject.Inject
@@ -19,11 +20,10 @@ abstract class SourceSetAutoInstallExtension @Inject constructor(project: Projec
     /**
      * Overrides the default Sentry Kotlin Multiplatform SDK dependency version.
      *
-     * Defaults to the latest version of the Sentry Kotlin Multiplatform SDK which is
-     * the same as the version of the Sentry Gradle Plugin.
+     * Defaults to the version of this plugin which is synchronized with the KMP SDK version.
      */
     val sentryKmpVersion: Property<String> =
         objects
             .property(String::class.java)
-            .convention(project.version.toString())
+            .convention(BuildConfig.SentryKmpVersion)
 }

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 
 class SentryPluginTest {
@@ -80,8 +82,31 @@ class SentryPluginTest {
         val project = ProjectBuilder.builder().build()
         project.pluginManager.apply("io.sentry.kotlin.multiplatform.gradle")
 
+        val sourceSetAutoInstallExtension = project.extensions.getByName("commonMain") as SourceSetAutoInstallExtension
+        assertEquals(BuildConfig.SentryKmpVersion, sourceSetAutoInstallExtension.sentryKmpVersion.get())
+    }
+
+    @Test
+    fun `custom kmp version overrides default in commonMain extension`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("io.sentry.kotlin.multiplatform.gradle")
+
         val autoInstallExtension = project.extensions.getByName("autoInstall") as AutoInstallExtension
-        assertEquals(BuildConfig.SentryKmpVersion, autoInstallExtension.commonMain.sentryKmpVersion.get())
+        autoInstallExtension.commonMain.sentryKmpVersion.set("1.2.3")
+
+        assertEquals("1.2.3", autoInstallExtension.commonMain.sentryKmpVersion.get())
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["1.0.0", "2.3.4-SNAPSHOT", "latest.release"])
+    fun `sentryKmpVersion accepts various version formats in commonMain extension`(version: String) {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("io.sentry.kotlin.multiplatform.gradle")
+
+        val autoInstallExtension = project.extensions.getByName("autoInstall") as AutoInstallExtension
+        autoInstallExtension.commonMain.sentryKmpVersion.set(version)
+
+        assertEquals(version, autoInstallExtension.commonMain.sentryKmpVersion.get())
     }
 
     @Test

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
@@ -1,14 +1,12 @@
 package io.sentry.kotlin.multiplatform.gradle
 
+import io.sentry.BuildConfig
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.cocoapods.CocoapodsExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -72,6 +70,15 @@ class SentryPluginTest {
         assertNotNull(project.extensions.getByName("autoInstall"))
         assertNotNull(project.extensions.getByName("cocoapods"))
         assertNotNull(project.extensions.getByName("commonMain"))
+    }
+
+    @Test
+    fun `default kmp version is set in commonMain extension`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("io.sentry.kotlin.multiplatform.gradle")
+
+        val autoInstallExtension = project.extensions.getByName("autoInstall") as AutoInstallExtension
+        assertEquals(BuildConfig.SentryKmpVersion, autoInstallExtension.commonMain.sentryKmpVersion.get())
     }
 
     @Test

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
@@ -6,7 +6,10 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.cocoapods.CocoapodsExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File


### PR DESCRIPTION
## :scroll: Description
Don't always use latest version.
<!--- Describe your changes in detail -->

## :bulb: Motivation and Context
Keeps versioning predictable

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps