### PR TITLE
fix(publish): fetch javadoc for 2 digit release numbers

### DIFF
--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -31,7 +31,7 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
         from("build${sep}libs") {
             include("${project.name}-kotlin*")
             include("${project.name}-metadata*")
-            withJavadoc(project.name, "")
+            withJavadoc(project.name)
             rename {
                 it.replace("multiplatform-kotlin", "multiplatform").replace("-metadata", "")
             }

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -1,14 +1,9 @@
-
 import org.gradle.api.Project
 import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.file.CopySpec
 import java.io.File
 
-private object Consts {
-    val taskRegex = Regex("(.*)DistZip")
-}
-
-val sep = File.separator
+val sep: String = File.separator
 
 // configure distZip tasks for multiplatform
 fun DistributionContainer.configureForMultiplatform(project: Project) {
@@ -27,7 +22,10 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
         }
         from("build${sep}kotlinToolingMetadata") {
             rename {
-                it.replace("kotlin-tooling-metadata.json", "${project.name}-$version-kotlin-tooling-metadata.json")
+                it.replace(
+                    "kotlin-tooling-metadata.json",
+                    "${project.name}-$version-kotlin-tooling-metadata.json"
+                )
             }
         }
         from("build${sep}libs") {


### PR DESCRIPTION
## :scroll: Description
Current way of fetching the javadoc only works on 1 digit e.g `0.9.0` but not 2 digits `0.10.0`
<!--- Describe your changes in detail -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.

#skip-changelog

