### PR TITLE
chore: Add date range for MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Sentry
+Copyright (c) 2020-2025 Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Add 2025 for the date range of the licence.

#skip-changelog