### PR TITLE
Add `sendDefaultPii` option

### DIFF
--- a/sentry-kotlin-multiplatform/src/androidUnitTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.android.kt
+++ b/sentry-kotlin-multiplatform/src/androidUnitTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.android.kt
@@ -73,6 +73,9 @@ class SentryAndroidOptionsWrapper(private val androidOptions: SentryAndroidOptio
     override val sessionReplay: AndroidSentryReplayOptions
         get() = androidOptions.sessionReplay
 
+    override val sendDefaultPii: Boolean
+        get() = androidOptions.isSendDefaultPii
+
     override fun applyFromOptions(options: SentryOptions) {
         options.toAndroidSentryOptionsCallback().invoke(androidOptions)
     }

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
@@ -54,6 +54,9 @@ open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOption
     override val diagnosticLevel: SentryLevel
         get() = cocoaOptions.diagnosticLevel.toKmpSentryLevel()!!
 
+    override val sendDefaultPii: Boolean
+        get() = cocoaOptions.sendDefaultPii
+
     override fun applyFromOptions(options: SentryOptions) {
         options.toCocoaOptionsConfiguration().invoke(cocoaOptions)
     }

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryOptions.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryOptions.kt
@@ -192,6 +192,16 @@ public open class SentryOptions {
     public var sessionReplay: SentryReplayOptions = SentryReplayOptions()
 
     /**
+     * Set this option to true to send default PII data to Sentry.
+     * Among other things, enabling this will enable automatic IP address collection on events.
+     *
+     * For further details, refer to the documentation in the respective native SDKs:
+     * - [Cocoa](https://docs.sentry.io/platforms/apple/data-management/data-collected/)
+     * - [Android](https://docs.sentry.io/platforms/android/data-management/data-collected/)
+     */
+    public var sendDefaultPii: Boolean = false
+
+    /**
      * Experimental options for new features, these options are going to be promoted to SentryOptions
      * before GA.
      *

--- a/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.kt
+++ b/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.kt
@@ -14,6 +14,7 @@ interface CommonPlatformOptions {
     val maxAttachmentSize: Long
     val sampleRate: Double?
     val tracesSampleRate: Double?
+    val sendDefaultPii: Boolean
 
     fun applyFromOptions(options: SentryOptions)
 }

--- a/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
+++ b/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
@@ -133,6 +133,7 @@ class SentryOptionsTest : BaseSentryTest() {
         assertTrue(options.sessionReplay.maskAllImages)
         assertEquals(SentryReplayOptions.Quality.MEDIUM, options.sessionReplay.quality)
         assertTrue(options.enableWatchdogTerminationTracking)
+        assertFalse(options.sendDefaultPii)
     }
 
     @Test
@@ -163,6 +164,7 @@ class SentryOptionsTest : BaseSentryTest() {
             sessionReplay.maskAllText = false
             sessionReplay.maskAllImages = false
             sessionReplay.quality = SentryReplayOptions.Quality.LOW
+            sendDefaultPii = true
         }
 
         val platformOptions = createPlatformOptions()


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps