### PR TITLE
Update sentry cocoa version compat in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Use the Kotlin Multiplatform and Cocoa SDK combinations listed in the table belo
 | 0.10.0                           | 8.38.0            |
 | 0.11.0                           | 8.44.0            |
 | 0.12.0                           | 8.49.0 (Xcode 16.3 compatible) |
+| 0.13.0                           | 8.49.1            |
 
 ## Usage
 


### PR DESCRIPTION
#skip-changelog

Closes #409 