### PR TITLE
chore: update craft config to support publish of new targets

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -13,8 +13,9 @@ targets:
       fileReplaceeRegex: /\d+\.\d+\.\d+(-\w+(\.\d+)?)?(-SNAPSHOT)?/
       fileReplacerStr: release.aar
     kmp:
-      rootDistDirRegex: /^(?!.*(?:jvm|android|ios|watchos|tvos|macos)).*$/
+      rootDistDirRegex: /^(?!.*(?:jvm|android|ios|watchos|tvos|macos|js|wasm-js|linux|mingw)).*$/
       appleDistDirRegex: /(ios|watchos|tvos|macos)/
+      klibDistDirRegex: /(js|wasm-js|linux|mingw)/
     excludeNames: /sentry-kotlin-multiplatform-gradle-plugin.*$/
   - name: maven
     id: plugin


### PR DESCRIPTION
#skip-changelog

Blocked by https://github.com/getsentry/craft/pull/612 and it must be released first