### PR TITLE
fix(gradle-plugin): allow new targets to be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.17.0
+## Unreleased
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+- Gradle Plugin: allow new supported targets to be installed ([#429](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/429))
+
+## 0.17.0
+
 ### Features
 
 - Add stubs/no-op support for unsupported targets ([#426](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/426))

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/main/java/io/sentry/kotlin/multiplatform/gradle/SentryPlugin.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/main/java/io/sentry/kotlin/multiplatform/gradle/SentryPlugin.kt
@@ -149,14 +149,14 @@ internal fun Project.installSentryForKmp(
         return
     }
 
-    val unsupportedTargets = listOf("wasm", "js", "mingw", "linux", "androidNative")
+    val unsupportedTargets = listOf("androidNative")
     kmpExtension.targets.forEach { target ->
         if (unsupportedTargets.any { unsupported -> target.name.contains(unsupported) }) {
             throw GradleException(
                 "Unsupported target: ${target.name}. " +
                     "Cannot auto install in commonMain. " +
                     "Please create an intermediate sourceSet with targets that the Sentry SDK " +
-                    "supports (apple, jvm, android) and add the dependency manually."
+                    "supports and add the dependency manually."
             )
         }
     }

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
@@ -6,7 +6,6 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.cocoapods.CocoapodsExtension
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull

--- a/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
+++ b/sentry-kotlin-multiplatform-gradle-plugin/src/test/java/io/sentry/kotlin/multiplatform/gradle/SentryPluginTest.kt
@@ -154,9 +154,8 @@ class SentryPluginTest {
         assertTrue(commonMainConfiguration!!.dependencies.contains(sentryDependency))
     }
 
-    @OptIn(ExperimentalWasmDsl::class)
     @ParameterizedTest(name = "installSentryForKmp throws if build contains unsupported target {0}")
-    @ValueSource(strings = ["wasm", "js", "mingw", "linux", "androidNative"])
+    @ValueSource(strings = ["androidNative"])
     fun `installSentryForKmp throws if build contains any unsupported target`(unsupportedTarget: String) {
         val project = ProjectBuilder.builder().build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
@@ -165,10 +164,6 @@ class SentryPluginTest {
         val kmpExtension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
         kmpExtension.apply {
             when (unsupportedTarget) {
-                "wasm" -> wasmJs()
-                "js" -> js()
-                "mingw" -> mingwX64()
-                "linux" -> linuxX64()
                 "androidNative" -> androidNativeArm64()
             }
         }


### PR DESCRIPTION
Allow the gradle plugin to install new targets, currently it's blocking it