### PR TITLE
Fix Sentry kmp stack trace crash on ios

### DIFF
--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/nsexception/Throwable.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/nsexception/Throwable.kt
@@ -75,9 +75,12 @@ internal fun List<Long>.dropInitAddresses(
 internal fun List<Long>.dropCommonAddresses(
     commonAddresses: List<Long>
 ): List<Long> {
-    var i = commonAddresses.size
-    if (i == 0) return this
+    if (commonAddresses.isEmpty()) return this
+
+    var i = commonAddresses.lastIndex // start from last valid index
     return dropLastWhile {
-        i-- >= 0 && commonAddresses[i] == it
+        val keep = i >= 0 && commonAddresses[i] == it
+        i--
+        keep
     }
 }


### PR DESCRIPTION
## :scroll: Description

Fixes an `IndexOutOfBoundsException` that occurred in `dropCommonAddresses` when processing stack traces on Kotlin/Native iOS.

## :bulb: Motivation and Context

The crash was caused by an incorrect index calculation in the `dropCommonAddresses` function within the `appleMain` source set. Specifically, the `i-- >= 0 && commonAddresses[i] == it` condition could lead to an attempt to access `commonAddresses[-1]`, triggering an `IndexOutOfBoundsException`. This issue was specific to Apple targets as the `asNSException` bridge, which utilizes this function, is only invoked on those platforms.

This PR corrects the indexing logic to ensure `commonAddresses` is accessed within valid bounds, preventing the crash.

## :green_heart: How did you test it?

The fix was verified by reproducing the `IndexOutOfBoundsException` crash on an iOS target and confirming that the application no longer crashes after applying the patch.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

Release a new version of the Sentry Kotlin Multiplatform SDK including this fix.

---
<a href="https://cursor.com/background-agent?bcId=bc-2211a961-27bb-4ec4-aa97-7874d81cc96e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2211a961-27bb-4ec4-aa97-7874d81cc96e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>