### PR TITLE
Fix Sentry kmp stack trace crash on ios

### DIFF
--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/nsexception/Throwable.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/nsexception/Throwable.kt
@@ -75,9 +75,16 @@ internal fun List<Long>.dropInitAddresses(
 internal fun List<Long>.dropCommonAddresses(
     commonAddresses: List<Long>
 ): List<Long> {
-    var i = commonAddresses.size
-    if (i == 0) return this
-    return dropLastWhile {
-        i-- >= 0 && commonAddresses[i] == it
+    if (commonAddresses.isEmpty() || this.isEmpty()) return this
+    
+    var commonIndex = commonAddresses.size - 1
+    return dropLastWhile { address ->
+        if (commonIndex < 0 || commonIndex >= commonAddresses.size) {
+            false
+        } else {
+            val matches = commonAddresses[commonIndex] == address
+            if (matches) commonIndex--
+            matches
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Description

Fixes an `IndexOutOfBoundsException` in the `dropCommonAddresses` function when processing stack traces on Kotlin/Native iOS. The issue was caused by incorrect index handling during the `dropLastWhile` operation.

## :bulb: Motivation and Context

Users encountered a crash (`kotlin.IndexOutOfBoundsException: index: -1`) when Sentry attempted to process Swift/Objective-C stack traces on iOS, specifically within the `dropCommonAddresses` function. This fix addresses the root cause by ensuring safe index management and preventing out-of-bounds access during stack trace filtering.

## :green_heart: How did you test it?

Existing unit tests were run to verify the fix and ensure no regressions.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

Release this fix in an upcoming version to allow users to update their Sentry KMP dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e4169eb-9090-4135-8f97-bc49ba2e90b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e4169eb-9090-4135-8f97-bc49ba2e90b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>