### PR TITLE
Update `update-cocoa.sh` to also update the sample podspec and run `pod update`

### DIFF
--- a/scripts/update-cocoa.sh
+++ b/scripts/update-cocoa.sh
@@ -77,7 +77,7 @@ set-version)
 
     # Run pod update in the sample iOS app directory to update Podfile.lock
     echo "Running pod update in $sample_ios_app_dir..."
-    (cd $sample_ios_app_dir && pod update --no-repo-update)
+    (cd $sample_ios_app_dir && pod update)
     ;;
 *)
     echo "Unknown argument $1"


### PR DESCRIPTION
#skip-changelog

Currently the cocoa update PRs always fail because it fails to updated the sample dependency as well

This PR updates the impl to enable updating the sample dependency as well. Before I had to do it manually and push it manually which was cumbersome
