### PR TITLE
chore: Add AGENTS.md, CLAUDE.md symlink, and Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,66 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(pwd:*)",
+      "Bash(file:*)",
+      "Bash(stat:*)",
+      "Bash(wc:*)",
+      "Bash(tree:*)",
+
+      "Bash(git pull:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git tag:*)",
+      "Bash(git stash list:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git fetch:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git blame:*)",
+
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run logs:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh api:*)",
+
+      "Bash(./gradlew tasks:*)",
+      "Bash(./gradlew dependencies:*)",
+      "Bash(./gradlew build:*)",
+      "Bash(./gradlew clean:*)",
+      "Bash(./gradlew test:*)",
+      "Bash(./gradlew detekt:*)",
+      "Bash(./gradlew spotlessKotlinCheck:*)",
+      "Bash(./gradlew spotlessApply:*)",
+      "Bash(./gradlew apiCheck:*)",
+      "Bash(./gradlew koverXmlReport:*)",
+      "Bash(./gradlew dokkaHtmlMultiModule:*)",
+      "Bash(./gradlew publishToMavenLocal:*)",
+      "Bash(./gradlew --stop:*)",
+      "Bash(make:*)",
+
+      "WebFetch(domain:docs.sentry.io)",
+      "WebFetch(domain:develop.sentry.dev)",
+      "WebFetch(domain:kotlinlang.org)",
+      "WebFetch(domain:developer.android.com)",
+      "WebFetch(domain:docs.github.com)",
+      "WebFetch(domain:cli.github.com)",
+
+      "Skill(sentry-skills:agents-md)"
+    ],
+    "deny": []
+  }
+}

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+Sentry Kotlin Multiplatform (KMP) SDK and Gradle Plugin.
+
+## Build
+
+- **Build tool**: Gradle via `./gradlew`
+- **Format**: `./gradlew spotlessApply`
+- **Lint**: `./gradlew detekt`
+- **Test**: `./gradlew build` (builds and runs tests)
+- **API check**: `./gradlew apiCheck` (binary compatibility)
+- **Full CI**: `make compile` (runs apiCheck, detekt, build, samples)
+
+## Quality Gate
+
+Before committing, ensure these pass:
+```bash
+./gradlew spotlessApply
+./gradlew detekt
+./gradlew build
+./gradlew apiCheck
+```
+
+## Repository Structure
+
+```
+├── sentry-kotlin-multiplatform/              # Core KMP SDK
+│   └── src/
+│       ├── commonMain/                       # Shared API & expect declarations
+│       ├── commonJvmMain/                    # Shared JVM + Android code
+│       ├── androidMain/                      # Android actual implementations
+│       ├── jvmMain/                          # JVM actual implementations
+│       ├── appleMain/                        # Shared Apple (iOS/macOS/tvOS/watchOS)
+│       ├── iosMain/                          # iOS-specific
+│       └── commonTvWatchMacOsMain/           # tvOS/watchOS/macOS-specific
+├── sentry-kotlin-multiplatform-gradle-plugin/ # Optional Gradle Plugin
+├── sentry-samples/                           # Sample apps (CocoaPods & SPM)
+└── buildSrc/                                 # Build configuration (Config.kt)
+```
+
+## Key Conventions
+
+- **expect/actual pattern**: Shared API in `commonMain`, platform implementations in `androidMain`, `appleMain`, `jvmMain`, etc.
+- **Public API docs**: All public classes/properties in `commonMain` must have KDoc (enforced by detekt)
+- **Formatting**: Spotless with ktlint — run `./gradlew spotlessApply` before committing
+- **Detekt config**: `config/detekt/detekt.yml`
+
+## Commit Attribution
+
+AI commits MUST include:
+```
+Co-Authored-By: (the agent model's name and attribution byline)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## :scroll: Description

Adds agent-facing documentation and Claude Code project settings for this repository:

- **AGENTS.md** — build commands, quality gate, repo structure, KMP conventions, and commit attribution
- **CLAUDE.md** — symlink to AGENTS.md
- **.claude/settings.json** — pre-approved permissions for Gradle, git, and GitHub CLI commands tailored for Kotlin Multiplatform development

## :bulb: Motivation and Context

Provides LLM coding agents (Claude Code, etc.) with the project context they need to work effectively: which commands to run, how the source sets are organized, and what quality checks must pass before committing.

## :green_heart: How did you test it?

Documentation and config only — no code changes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

None — iterative improvements to AGENTS.md as we learn what works best.