### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: JDK setup
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   changelog-preview:
-    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@f4889d04564e47311038ecb6b910fef6b6cf1363 # v2
     secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,4 +8,4 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/danger@v3
+      - uses: getsentry/github-workflows/danger@26f565c05d0dd49f703d238706b775883037d76b # v3

--- a/.github/workflows/generate-dokka.yml
+++ b/.github/workflows/generate-dokka.yml
@@ -20,16 +20,16 @@
 #      url: ${{ steps.deployment.outputs.page_url }}
 #    steps:
 #      - name: Checkout
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 #
 #      - name: set up JDK 11
-#        uses: actions/setup-java@v4
+#        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
 #        with:
 #          distribution: "adopt"
 #          java-version: "11"
 #
 #      - name: Cache Gradle packages
-#        uses: actions/cache@v4
+#        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
 #        with:
 #          path: |
 #            ~/.gradle/caches
@@ -39,16 +39,16 @@
 #            ${{ runner.os }}-gradle-
 #
 #      - name: Setup Pages
-#        uses: actions/configure-pages@v5
+#        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 #
 #      - name: Generate docs with dokka
 #        run: make generateDokka
 #
 #      - name: Upload artifact
-#        uses: actions/upload-pages-artifact@v3
+#        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
 #        with:
 #          path: ${{ github.workspace }}/build/dokka/htmlMultiModule
 #
 #      - name: Deploy to GitHub Pages
 #        id: deployment
-#        uses: actions/deploy-pages@v1
+#        uses: actions/deploy-pages@f27bcc15848fdcdcc02f01754eb838e44bcf389b # v1

--- a/.github/workflows/kotlin-multiplatform-gradle-plugin.yml
+++ b/.github/workflows/kotlin-multiplatform-gradle-plugin.yml
@@ -24,16 +24,16 @@ jobs:
         working-directory: sentry-kotlin-multiplatform-gradle-plugin
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: JDK setup
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: temurin
 
       - name: Cached Konan
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/kotlin-multiplatform.yml
+++ b/.github/workflows/kotlin-multiplatform.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: macos-latest-xlarge
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: JDK setup
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: temurin
 
       - name: Cached Konan
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
@@ -49,16 +49,16 @@ jobs:
     runs-on: macos-latest-xlarge
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: JDK setup
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: temurin
 
       - name: Cached Konan
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
@@ -75,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: JDK setup
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: temurin
@@ -105,10 +105,10 @@ jobs:
     runs-on: macos-latest-xlarge
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: JDK setup
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   cocoa:
     uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cocoa:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
     with:
       path: scripts/update-cocoa.sh
       name: Cocoa SDK
@@ -18,7 +18,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   java:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
     with:
       path: scripts/update-java.sh
       name: Java SDK

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: macos-latest-xlarge
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: JDK setup
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 17
           distribution: temurin
@@ -38,7 +38,7 @@ jobs:
           ./gradlew validateDistributions
 
       - name: Archive packages
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ github.sha }}
           if-no-files-found: error


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)