### PR TITLE
feat(apple): Add C++ exception monitor option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add C++ exception monitor option ([#554](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/554))
+
 ## 0.26.0
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add C++ exception monitor option ([#554](https://github.com/getsentry/sentry-kotlin-multiplatform/pull/554))
+  - **Compose Multiplatform**: It is highly recommended to disable C++ monitoring (`options.enableUnhandledCppExceptionMonitoring = false`) on Apple targets. Unhandled Kotlin exceptions from CMP can be reported as generic C++ crashes (`ExceptionObjHolderImpl`) instead of useful Kotlin stack traces when C++ monitoring is enabled.
 
 ## 0.26.0
 

--- a/sentry-kotlin-multiplatform/api/android/sentry-kotlin-multiplatform.api
+++ b/sentry-kotlin-multiplatform/api/android/sentry-kotlin-multiplatform.api
@@ -251,6 +251,7 @@ public class io/sentry/kotlin/multiplatform/SentryOptions {
 	public final fun getEnableAppHangTracking ()Z
 	public final fun getEnableAutoSessionTracking ()Z
 	public final fun getEnableCaptureFailedRequests ()Z
+	public final fun getEnableUnhandledCppExceptionMonitoring ()Z
 	public final fun getEnableWatchdogTerminationTracking ()Z
 	public final fun getEnvironment ()Ljava/lang/String;
 	public final fun getExperimental ()Lio/sentry/kotlin/multiplatform/SentryOptions$ExperimentalOptions;
@@ -284,6 +285,7 @@ public class io/sentry/kotlin/multiplatform/SentryOptions {
 	public final fun setEnableAppHangTracking (Z)V
 	public final fun setEnableAutoSessionTracking (Z)V
 	public final fun setEnableCaptureFailedRequests (Z)V
+	public final fun setEnableUnhandledCppExceptionMonitoring (Z)V
 	public final fun setEnableWatchdogTerminationTracking (Z)V
 	public final fun setEnvironment (Ljava/lang/String;)V
 	public final fun setFailedRequestStatusCodes (Ljava/util/List;)V

--- a/sentry-kotlin-multiplatform/api/jvm/sentry-kotlin-multiplatform.api
+++ b/sentry-kotlin-multiplatform/api/jvm/sentry-kotlin-multiplatform.api
@@ -248,6 +248,7 @@ public class io/sentry/kotlin/multiplatform/SentryOptions {
 	public final fun getEnableAppHangTracking ()Z
 	public final fun getEnableAutoSessionTracking ()Z
 	public final fun getEnableCaptureFailedRequests ()Z
+	public final fun getEnableUnhandledCppExceptionMonitoring ()Z
 	public final fun getEnableWatchdogTerminationTracking ()Z
 	public final fun getEnvironment ()Ljava/lang/String;
 	public final fun getExperimental ()Lio/sentry/kotlin/multiplatform/SentryOptions$ExperimentalOptions;
@@ -281,6 +282,7 @@ public class io/sentry/kotlin/multiplatform/SentryOptions {
 	public final fun setEnableAppHangTracking (Z)V
 	public final fun setEnableAutoSessionTracking (Z)V
 	public final fun setEnableCaptureFailedRequests (Z)V
+	public final fun setEnableUnhandledCppExceptionMonitoring (Z)V
 	public final fun setEnableWatchdogTerminationTracking (Z)V
 	public final fun setEnvironment (Ljava/lang/String;)V
 	public final fun setFailedRequestStatusCodes (Ljava/util/List;)V

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryApple.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/SentryApple.kt
@@ -1,10 +1,29 @@
 package io.sentry.kotlin.multiplatform
 
+import Internal.Sentry.SentryCrashMonitorTypeCPPException
+import Internal.Sentry.SentryDependencyContainer
 import cocoapods.Sentry.SentrySDK
 import io.sentry.kotlin.multiplatform.nsexception.setSentryUnhandledExceptionHook
 
 /** Convenience extension to setup unhandled exception hook */
 internal fun SentrySDK.Companion.start(configuration: (CocoaSentryOptions?) -> Unit) {
+    setEnableUnhandledCppExceptionMonitoring(true)
     startWithConfigureOptions(configuration)
+    if (!isUnhandledCppExceptionMonitoringEnabled()) {
+        disableCppExceptionMonitor()
+    }
     setSentryUnhandledExceptionHook()
+}
+
+private var enableUnhandledCppExceptionMonitoring = true
+
+internal fun setEnableUnhandledCppExceptionMonitoring(enabled: Boolean) {
+    enableUnhandledCppExceptionMonitoring = enabled
+}
+
+internal fun isUnhandledCppExceptionMonitoringEnabled(): Boolean = enableUnhandledCppExceptionMonitoring
+
+private fun disableCppExceptionMonitor() {
+    val crashReporter = SentryDependencyContainer.sharedInstance().crashReporter
+    crashReporter.monitoring = crashReporter.monitoring and SentryCrashMonitorTypeCPPException.inv()
 }

--- a/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.apple.kt
@@ -7,6 +7,7 @@ import io.sentry.kotlin.multiplatform.SentryEvent
 import io.sentry.kotlin.multiplatform.SentryOptions
 import io.sentry.kotlin.multiplatform.log.toKmpSentryLog
 import io.sentry.kotlin.multiplatform.log.updateFrom
+import io.sentry.kotlin.multiplatform.setEnableUnhandledCppExceptionMonitoring
 import kotlinx.cinterop.convert
 import platform.Foundation.NSNumber
 
@@ -37,6 +38,7 @@ internal fun CocoaSentryOptions.applyCocoaBaseOptions(kmpOptions: SentryOptions)
     cocoaOptions.enableWatchdogTerminationTracking = kmpOptions.enableWatchdogTerminationTracking
     cocoaOptions.appHangTimeoutInterval = kmpOptions.appHangTimeoutIntervalMillis.toDouble()
     cocoaOptions.diagnosticLevel = kmpOptions.diagnosticLevel.toCocoaSentryLevel()
+    setEnableUnhandledCppExceptionMonitoring(kmpOptions.enableUnhandledCppExceptionMonitoring)
     cocoaOptions.experimental().setEnableLogs(kmpOptions.logs.enabled)
     kmpOptions.logs.beforeSend?.let { kmpBeforeSend ->
         cocoaOptions.setBeforeSendLog { cocoaLog ->

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
@@ -68,10 +68,12 @@ open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOption
 
     override fun applyFromOptions(options: SentryOptions) {
         options.toCocoaOptionsConfiguration().invoke(cocoaOptions)
-        cacheAppliedOptions()
+        cacheAppliedUnhandledCppExceptionMonitoring()
     }
 
-    protected fun cacheAppliedOptions() {
+    protected fun cacheAppliedUnhandledCppExceptionMonitoring() {
+        // This KMP-only option is applied through an internal global, not Cocoa options.
+        // Snapshot it after apply so each test wrapper keeps its own applied value.
         cachedEnableUnhandledCppExceptionMonitoring = isUnhandledCppExceptionMonitoringEnabled()
     }
 }

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertEquals
 
 actual interface PlatformOptions : CommonPlatformOptions {
     val enableWatchdogTerminationTracking: Boolean
+    val enableUnhandledCppExceptionMonitoring: Boolean
 }
 
 open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOptions) :
@@ -51,6 +52,9 @@ open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOption
     override val enableWatchdogTerminationTracking: Boolean
         get() = cocoaOptions.enableWatchdogTerminationTracking
 
+    override val enableUnhandledCppExceptionMonitoring: Boolean
+        get() = isUnhandledCppExceptionMonitoringEnabled()
+
     override val diagnosticLevel: SentryLevel
         get() = cocoaOptions.diagnosticLevel.toKmpSentryLevel()!!
 
@@ -78,6 +82,7 @@ actual fun PlatformOptions.assertPlatformSpecificOptions(kmpOptions: SentryOptio
 
     val appleOptions = this
     assertEquals(appleOptions.enableWatchdogTerminationTracking, kmpOptions.enableWatchdogTerminationTracking)
+    assertEquals(appleOptions.enableUnhandledCppExceptionMonitoring, kmpOptions.enableUnhandledCppExceptionMonitoring)
 }
 
 actual fun createSentryPlatformOptionsConfiguration(): PlatformOptionsConfiguration = {

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
@@ -68,6 +68,10 @@ open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOption
 
     override fun applyFromOptions(options: SentryOptions) {
         options.toCocoaOptionsConfiguration().invoke(cocoaOptions)
+        cacheAppliedOptions(options)
+    }
+
+    protected fun cacheAppliedOptions(options: SentryOptions) {
         cachedEnableUnhandledCppExceptionMonitoring = options.enableUnhandledCppExceptionMonitoring
     }
 }

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
@@ -68,11 +68,11 @@ open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOption
 
     override fun applyFromOptions(options: SentryOptions) {
         options.toCocoaOptionsConfiguration().invoke(cocoaOptions)
-        cacheAppliedOptions(options)
+        cacheAppliedOptions()
     }
 
-    protected fun cacheAppliedOptions(options: SentryOptions) {
-        cachedEnableUnhandledCppExceptionMonitoring = options.enableUnhandledCppExceptionMonitoring
+    protected fun cacheAppliedOptions() {
+        cachedEnableUnhandledCppExceptionMonitoring = isUnhandledCppExceptionMonitoringEnabled()
     }
 }
 

--- a/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
+++ b/sentry-kotlin-multiplatform/src/appleTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.apple.kt
@@ -13,6 +13,8 @@ actual interface PlatformOptions : CommonPlatformOptions {
 
 open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOptions) :
     PlatformOptions {
+    private var cachedEnableUnhandledCppExceptionMonitoring = true
+
     override val dsn: String?
         get() = cocoaOptions.dsn
 
@@ -53,7 +55,7 @@ open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOption
         get() = cocoaOptions.enableWatchdogTerminationTracking
 
     override val enableUnhandledCppExceptionMonitoring: Boolean
-        get() = isUnhandledCppExceptionMonitoringEnabled()
+        get() = cachedEnableUnhandledCppExceptionMonitoring
 
     override val diagnosticLevel: SentryLevel
         get() = cocoaOptions.diagnosticLevel.toKmpSentryLevel()!!
@@ -66,6 +68,7 @@ open class SentryAppleOptionsWrapper(private val cocoaOptions: CocoaSentryOption
 
     override fun applyFromOptions(options: SentryOptions) {
         options.toCocoaOptionsConfiguration().invoke(cocoaOptions)
+        cachedEnableUnhandledCppExceptionMonitoring = options.enableUnhandledCppExceptionMonitoring
     }
 }
 

--- a/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryOptions.kt
+++ b/sentry-kotlin-multiplatform/src/commonMain/kotlin/io/sentry/kotlin/multiplatform/SentryOptions.kt
@@ -187,6 +187,19 @@ public open class SentryOptions {
     public var enableWatchdogTerminationTracking: Boolean = true
 
     /**
+     * Whether to enable Cocoa's unhandled C++ exception monitoring on Apple targets.
+     *
+     * **Default**: Enabled.
+     *
+     * **Platform Availability**: Cocoa.
+     *
+     * Disabling this can help Kotlin/Native unhandled exceptions, especially crashes triggered from
+     * Compose Multiplatform callbacks, reach the KMP unhandled exception hook instead of being
+     * reported as Kotlin/Native's internal `ExceptionObjHolderImpl` C++ exception.
+     */
+    public var enableUnhandledCppExceptionMonitoring: Boolean = true
+
+    /**
      * The options for session replay.
      * Currently available for **Android** and **iOS**.
      */

--- a/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
+++ b/sentry-kotlin-multiplatform/src/commonTest/kotlin/io/sentry/kotlin/multiplatform/SentryOptionsTest.kt
@@ -133,6 +133,7 @@ class SentryOptionsTest : BaseSentryTest() {
         assertTrue(options.sessionReplay.maskAllImages)
         assertEquals(SentryReplayOptions.Quality.MEDIUM, options.sessionReplay.quality)
         assertTrue(options.enableWatchdogTerminationTracking)
+        assertTrue(options.enableUnhandledCppExceptionMonitoring)
         assertFalse(options.sendDefaultPii)
         assertNull(options.proguardUuid)
     }
@@ -160,6 +161,7 @@ class SentryOptionsTest : BaseSentryTest() {
             isAnrEnabled = false
             anrTimeoutIntervalMillis = 1000L
             enableWatchdogTerminationTracking = false
+            enableUnhandledCppExceptionMonitoring = false
             sessionReplay.onErrorSampleRate = 0.5
             sessionReplay.sessionSampleRate = 0.5
             sessionReplay.maskAllText = false

--- a/sentry-kotlin-multiplatform/src/iosTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.ios.kt
+++ b/sentry-kotlin-multiplatform/src/iosTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.ios.kt
@@ -30,7 +30,7 @@ class SentryIosOptionsWrapper(private val cocoaOptions: CocoaSentryOptions) : Se
 
     override fun applyFromOptions(options: SentryOptions) {
         options.toIosOptionsConfiguration().invoke(cocoaOptions)
-        cacheAppliedOptions(options)
+        cacheAppliedOptions()
     }
 }
 

--- a/sentry-kotlin-multiplatform/src/iosTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.ios.kt
+++ b/sentry-kotlin-multiplatform/src/iosTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.ios.kt
@@ -30,6 +30,7 @@ class SentryIosOptionsWrapper(private val cocoaOptions: CocoaSentryOptions) : Se
 
     override fun applyFromOptions(options: SentryOptions) {
         options.toIosOptionsConfiguration().invoke(cocoaOptions)
+        cacheAppliedOptions(options)
     }
 }
 

--- a/sentry-kotlin-multiplatform/src/iosTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.ios.kt
+++ b/sentry-kotlin-multiplatform/src/iosTest/kotlin/io/sentry/kotlin/multiplatform/PlatformOptions.ios.kt
@@ -30,7 +30,7 @@ class SentryIosOptionsWrapper(private val cocoaOptions: CocoaSentryOptions) : Se
 
     override fun applyFromOptions(options: SentryOptions) {
         options.toIosOptionsConfiguration().invoke(cocoaOptions)
-        cacheAppliedOptions()
+        cacheAppliedUnhandledCppExceptionMonitoring()
     }
 }
 

--- a/sentry-kotlin-multiplatform/src/nativeInterop/cinterop/SentryInternal/SentryCrash.h
+++ b/sentry-kotlin-multiplatform/src/nativeInterop/cinterop/SentryInternal/SentryCrash.h
@@ -1,8 +1,18 @@
 // SentryCrash interface - expose the uncaughtExceptionHandler
 // Based on: https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Sentry/include/SentryCrash.h
 
+typedef enum {
+    SentryCrashMonitorTypeMachException = 0x01,
+    SentryCrashMonitorTypeSignal = 0x02,
+    SentryCrashMonitorTypeCPPException = 0x04,
+    SentryCrashMonitorTypeNSException = 0x08,
+    SentryCrashMonitorTypeSystem = 0x40,
+    SentryCrashMonitorTypeApplicationState = 0x80,
+} SentryCrashMonitorType;
+
 @interface SentryCrash : NSObject
 
 @property (nonatomic, assign, nullable) NSUncaughtExceptionHandler *uncaughtExceptionHandler;
+@property (nonatomic, readwrite, assign) SentryCrashMonitorType monitoring;
 
 @end


### PR DESCRIPTION
## :scroll: Description

Add `enableUnhandledCppExceptionMonitoring` to KMP `SentryOptions` for Apple targets. The option defaults to `true` to preserve existing behavior, and when set to `false` the SDK disables Sentry Cocoa's C++ exception monitor after Cocoa initialization and before installing the KMP unhandled exception hook.

## :bulb: Motivation and Context

Compose Multiplatform 1.9.x can route Kotlin/Native crashes from Compose callbacks through Cocoa's C++ exception monitor first. Those crashes show up as Kotlin/Native's internal `ExceptionObjHolderImpl` C++ exception instead of the useful Kotlin exception report.

CMP users should disable C++ monitoring to get reliable and useful crash reports.

Fixes #476 

## :green_heart: How did you test it?

Ran:

```bash
./gradlew :sentry-kotlin-multiplatform:iosSimulatorArm64Test :sentry-kotlin-multiplatform:compileKotlinIosSimulatorArm64
```

Also published a local test build and verified a Compose Multiplatform repro resolves the local `iosSimulatorArm64` artifact with `enableUnhandledCppExceptionMonitoring = false`.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

Document this in docs so CMP users can disable it.

Made with [Cursor](https://cursor.com)